### PR TITLE
呕心沥血的重构，这才是牛油果db的正确使用方式

### DIFF
--- a/src/config/config_updater.py
+++ b/src/config/config_updater.py
@@ -107,7 +107,7 @@ def _sophisticated_merge_configs(
                     template_value.append(entry_table)  # 再把新的精华一个个注入！
                 logger.debug(f"  合并数组表 (AoT): '{key}' 已根据新模板结构融合旧值。")
 
-            # 姿势三：如果新旧两边都是普通的“珍珠串” (Array)，小猫觉得主人的旧珍珠串更合心意
+            # 姿势三：如果新旧两边都是普通的“点串” (Array)，小猫觉得主人的旧点串更合心意
             elif isinstance(template_value, Array) and isinstance(old_value, Array):
                 # 对于普通数组，我们直接用旧的覆盖新的，因为用户自定义的列表内容通常更重要。
                 # tomlkit 的 Array 支持 copy()

--- a/src/core_logic/consciousness_flow.py
+++ b/src/core_logic/consciousness_flow.py
@@ -4,7 +4,7 @@ import contextlib
 import datetime
 import threading
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from src.action.action_handler import ActionHandler
 from src.common.custom_logging.logging_config import get_logger
@@ -17,8 +17,8 @@ from src.core_logic.prompt_builder import ThoughtPromptBuilder
 from src.core_logic.state_manager import AIStateManager
 from src.core_logic.thought_generator import ThoughtGenerator
 from src.core_logic.thought_persistor import ThoughtPersistor
-from src.database.models import ThoughtChainDocument
 from src.database import ThoughtStorageService
+from src.database.models import ThoughtChainDocument
 
 if TYPE_CHECKING:
     from src.focus_chat_mode.chat_session_manager import ChatSessionManager
@@ -98,7 +98,7 @@ class CoreLogic:
         self.context_builder = context_builder
         self.thought_generator = thought_generator
         self.thought_persistor = thought_persistor
-        self.thought_storage_service = thought_storage_service # 把存储服务也存起来
+        self.thought_storage_service = thought_storage_service  # 把存储服务也存起来
         self.prompt_builder = prompt_builder
         self.stop_event = stop_event
         self.immediate_thought_trigger = immediate_thought_trigger
@@ -172,7 +172,7 @@ class CoreLogic:
         if action_payload:
             await self.action_handler_instance.process_action_flow(
                 action_id=action_id,
-                doc_key_for_updates=saved_thought_key, # 这个参数现在可以考虑去掉了，因为动作日志是独立的
+                doc_key_for_updates=saved_thought_key,  # 这个参数现在可以考虑去掉了，因为动作日志是独立的
                 action_json=action_payload,
             )
 
@@ -217,10 +217,10 @@ class CoreLogic:
                     mood=generated_thought_json.get("mood", "平静"),
                     think=generated_thought_json.get("think", "无"),
                     goal=generated_thought_json.get("goal"),
-                    source_type='core',
+                    source_type="core",
                     source_id=None,
                     action_id=action_id,
-                    action_payload=action_payload
+                    action_payload=action_payload,
                 )
 
                 # 4. 把点串到链上去！
@@ -282,9 +282,9 @@ class CoreLogic:
             mood="平静",
             think="根据LLM指令激活新专注会话",
             goal="激活指定会话",
-            source_type='core',
+            source_type="core",
             source_id=None,
             action_id=str(uuid.uuid4()),
-            action_payload=mock_action_payload
+            action_payload=mock_action_payload,
         )
         await self._dispatch_action(mock_thought_pearl)

--- a/src/core_logic/consciousness_flow.py
+++ b/src/core_logic/consciousness_flow.py
@@ -161,8 +161,8 @@ class CoreLogic:
                 if not action_payload.get("napcat_qq"):
                     del action_payload["napcat_qq"]
 
-                    # 既然是 focus，那就返回 True
-                    return True
+                # 既然是 focus，那就返回 True
+                return True
 
             except Exception as e:
                 logger.error(f"主意识在处理 'focus' 指令时发生错误: {e}", exc_info=True)

--- a/src/core_logic/state_manager.py
+++ b/src/core_logic/state_manager.py
@@ -50,10 +50,10 @@ class AIStateManager:
             state_blocks["think_block"] = f"你刚才的内心想法是：{latest_thought.get('think', '我好像忘了刚才在想啥')}"
 
             goal_db = latest_thought.get("goal")
-            if goal_db and goal_db.strip().lower() != 'null':
-                 state_blocks["goal_block"] = f"你当前的目标是：【{goal_db}】"
+            if goal_db and goal_db.strip().lower() != "null":
+                state_blocks["goal_block"] = f"你当前的目标是：【{goal_db}】"
             else:
-                 state_blocks["goal_block"] = self.INITIAL_STATE["goal_block"]
+                state_blocks["goal_block"] = self.INITIAL_STATE["goal_block"]
 
             # // 动作相关的逻辑也简单多了
             # // 我们不再需要复杂的 action_request 和 action_response 块了，
@@ -66,7 +66,7 @@ class AIStateManager:
                     if actions:
                         action_name, _ = next(iter(actions.items()), (None, None))
                         if platform and action_name:
-                             action_desc = f"在平台 '{platform}' 执行 '{action_name}'"
+                            action_desc = f"在平台 '{platform}' 执行 '{action_name}'"
 
                 state_blocks["action_request_block"] = f'你刚才的想法导致你试图执行动作"{action_desc}"。'
                 state_blocks["action_response_block"] = "该行动的后续状态和结果，请参考下面的行动日志。"

--- a/src/core_logic/state_manager.py
+++ b/src/core_logic/state_manager.py
@@ -60,8 +60,7 @@ class AIStateManager:
             # // 因为动作信息已经通过 action_log_block 更清晰地展示
             if latest_thought.get("action_id"):
                 action_desc = "某个动作"
-                action_payload = latest_thought.get("action_payload", {})
-                if action_payload:
+                if action_payload := latest_thought.get("action_payload", {}):
                     # 随便解析第一个动作作为代表
                     platform, actions = next(iter(action_payload.items()), (None, None))
                     if actions:

--- a/src/core_logic/state_manager.py
+++ b/src/core_logic/state_manager.py
@@ -1,4 +1,4 @@
-# src/core_logic/state_manager.py
+# src/core_logic/state_manager.py (小懒猫·清爽版)
 import datetime
 from typing import Any
 
@@ -10,14 +10,16 @@ logger = get_logger(__name__)
 
 class AIStateManager:
     """
-    管理AI的内心世界，烦死了，这么多内心戏。
-    负责从数据库获取和处理AI的思考状态。
+    管理AI的内心世界，现在清爽多了，哼。
+    我只负责从思想链里拿最新的状态。
     """
 
+    # 这个初始状态仍然有用，在思想链还没有任何内容的时候，可以作为保底
     INITIAL_STATE: dict[str, Any] = {
         "mood_block": "你刚才的心情是：平静。",
         "think_block": "你刚才的内心想法是：这是你的第一次思考，请开始吧。",
         "goal_block": "你当前没有什么特定的目标或任务。",
+        # // 注意，这几个字段现在只在初始状态下或者思想链断裂时使用
         "action_request_block": "你上一轮没有试图执行任何动作。",
         "action_response_block": "因此也没有任何行动结果。",
         "action_log_block": "你最近没有执行过任何动作。",
@@ -29,112 +31,67 @@ class AIStateManager:
         """
         self.thought_service = thought_service
         self.action_log_service = action_log_service
-        self._next_handover_summary: str | None = None
-        self._next_last_focus_think: str | None = None
-        self._next_last_focus_mood: str | None = None
-        self.bot_profile_cache: dict[str, Any] = {}
-        logger.info("AIStateManager 初始化完毕，已准备好接收交接信息和处理动作日志。")
+        logger.info("AIStateManager (思想链版) 初始化完毕。")
 
-    def set_next_handover_info(
-        self, summary: str | None, last_focus_think: str | None, last_focus_mood: str | None
-    ) -> None:
-        """
-        存储从专注模式传递过来的交接信息，供下一轮思考使用。
-        哼，别想把这些重要的东西随便丢掉！
-        """
-        self._next_handover_summary = summary
-        self._next_last_focus_think = last_focus_think
-        self._next_last_focus_mood = last_focus_mood
-        log_parts = []
-        if summary:
-            log_parts.append(f"交接总结 (前50字符): '{summary[:50]}...'")
-        if last_focus_think:
-            log_parts.append(f"专注模式最后想法 (前50字符): '{last_focus_think[:50]}...'")
-        if last_focus_mood:
-            log_parts.append(f"专注模式最后心情: '{last_focus_mood}'")
-        if log_parts:
-            logger.info(f"AIStateManager 已接收到交接信息：{'; '.join(log_parts)}")
-        else:
-            logger.info("AIStateManager set_next_handover_info 被调用，但未提供有效信息。")
+    # // 看！那个烦人的 set_next_handover_info 不见了！我们再也不需要它了！
 
     async def get_current_state_for_prompt(self) -> dict[str, str]:
         """
-        从数据库获取最新的思考和动作日志，现在它能听懂新旧两种语言了！
+        从思想链获取最新的状态，构建Prompt需要的所有状态块。
         """
         state_blocks = self.INITIAL_STATE.copy()
 
-        # 1. 获取最新的思考文档
-        latest_thought_documents = await self.thought_service.get_latest_main_thought_document()
-        latest_thought = latest_thought_documents[0] if latest_thought_documents else None
+        # 1. 获取最新的思想点
+        latest_thought = await self.thought_service.get_latest_thought_document()
 
-        # 2. 构建心情、想法和目标块
+        # 2. 从点里拿出我们需要的东西，填充状态块
         if latest_thought:
-            # --- 看这里！这就是兼容性的魔法！ ---
-            # 它会先尝试找新字段 'mood'，找不到再去找旧字段 'emotion_output'
-            mood_db = latest_thought.get("mood") or latest_thought.get("emotion_output", "平静")
-            state_blocks["mood_block"] = f"你刚才的心情是：{mood_db}"
+            state_blocks["mood_block"] = f"你刚才的心情是：{latest_thought.get('mood', '平静')}"
+            state_blocks["think_block"] = f"你刚才的内心想法是：{latest_thought.get('think', '我好像忘了刚才在想啥')}"
 
-            # 同理，处理想法和目标
-            think_db = latest_thought.get("think") or latest_thought.get("think_output")
-            state_blocks["think_block"] = f"你刚才的内心想法是：{think_db}" if think_db else state_blocks["think_block"]
+            goal_db = latest_thought.get("goal")
+            if goal_db and goal_db.strip().lower() != 'null':
+                 state_blocks["goal_block"] = f"你当前的目标是：【{goal_db}】"
+            else:
+                 state_blocks["goal_block"] = self.INITIAL_STATE["goal_block"]
 
-            goal_db = (
-                latest_thought.get("goal")
-                if latest_thought.get("goal") != "null"
-                else latest_thought.get("to_do_output")
-            )
-            state_blocks["goal_block"] = f"你当前的目标是：【{goal_db}】" if goal_db else state_blocks["goal_block"]
-
-            # --- 动作处理也得改！ ---
-            # 先尝试找新的 `action` 字段，再找旧的 `action_attempted`
-            last_action_attempt = latest_thought.get("action") or latest_thought.get("action_attempted")
-
-            if last_action_attempt and isinstance(last_action_attempt, dict):
-                # 从新的 action_payload 中提取信息，或者从旧结构中提取
-                action_payload = last_action_attempt.get("action_payload", {})
-
-                # 兼容旧格式的 action_description
-                action_desc = "未知动作"
-                # 尝试从新结构解析
+            # // 动作相关的逻辑也简单多了
+            # // 我们不再需要复杂的 action_request 和 action_response 块了，
+            # // 因为动作信息已经通过 action_log_block 更清晰地展示
+            if latest_thought.get("action_id"):
+                action_desc = "某个动作"
+                action_payload = latest_thought.get("action_payload", {})
                 if action_payload:
-                    platform, actions = next(iter(action_payload.items()))
-                    action_name, params = next(iter(actions.items()))
-                    action_desc = f"在平台 '{platform}' 执行 '{action_name}'"
-                else:  # 兼容旧结构
-                    action_desc = last_action_attempt.get("action_description", "某个动作")
+                    # 随便解析第一个动作作为代表
+                    platform, actions = next(iter(action_payload.items()), (None, None))
+                    if actions:
+                        action_name, _ = next(iter(actions.items()), (None, None))
+                        if platform and action_name:
+                             action_desc = f"在平台 '{platform}' 执行 '{action_name}'"
 
-                # 兼容旧格式的 action_motivation
-                action_motive = "未知动机"
-                if action_payload:
-                    _, actions = next(iter(action_payload.items()))
-                    _, params = next(iter(actions.items()))
-                    action_motive = params.get("motivation", "未知动机")
-                else:
-                    action_motive = last_action_attempt.get("action_motivation", "某种动机")
+                state_blocks["action_request_block"] = f'你刚才的想法导致你试图执行动作"{action_desc}"。'
+                state_blocks["action_response_block"] = "该行动的后续状态和结果，请参考下面的行动日志。"
+            else:
+                # 如果最新的思考没有附带动作，就用初始的默认值
+                state_blocks["action_request_block"] = self.INITIAL_STATE["action_request_block"]
+                state_blocks["action_response_block"] = self.INITIAL_STATE["action_response_block"]
 
-                state_blocks["action_request_block"] = f'你刚才试图做的动作是:"{action_desc}"，因为:"{action_motive}"'
-
-                action_status = last_action_attempt.get("status")
-                if action_status in ["COMPLETED_SUCCESS", "COMPLETED_FAILURE", "CRITICAL_FAILURE"]:
-                    result_for_shimo = last_action_attempt.get("final_result_for_shimo")
-                    state_blocks["action_response_block"] = (
-                        f'你刚才的动作"{action_desc}"，{result_for_shimo or "没有返回具体信息。"}'
-                    )
-                elif action_status:
-                    state_blocks["action_response_block"] = (
-                        f'你刚才的动作"{action_desc}"，目前还在执行中(状态: {action_status})。'
-                    )
-                else:
-                    state_blocks["action_response_block"] = f'你刚才的动作"{action_desc}"，目前状态未知。'
-
-        # 4. 构建动作日志块
+        # 3. 动作日志照旧，这是唯一独立的外部信息源
         recent_logs = await self.action_log_service.get_recent_action_logs(limit=10)
         if recent_logs:
             log_lines = ["你最近执行过的动作有："]
             for log in reversed(recent_logs):  # 从旧到新显示
                 ts = datetime.datetime.fromtimestamp(log.get("timestamp", 0) / 1000.0)
                 time_str = ts.strftime("%H:%M:%S")
-                log_lines.append(f"- 在 {time_str}，你执行了动作: {log.get('action_type')}")
+                status = log.get("status", "未知")
+                error_info = log.get("error_info")
+                status_display = f"状态: {status}"
+                if error_info:
+                    status_display += f" (原因: {error_info[:30]}{'...' if len(error_info) > 30 else ''})"
+
+                log_lines.append(f"- 在 {time_str}，你执行了动作: {log.get('action_type')}，{status_display}")
             state_blocks["action_log_block"] = "\n".join(log_lines)
+        else:
+            state_blocks["action_log_block"] = self.INITIAL_STATE["action_log_block"]
 
         return state_blocks

--- a/src/core_logic/thought_generator.py
+++ b/src/core_logic/thought_generator.py
@@ -1,4 +1,5 @@
 # src/core_logic/thought_generator.py
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from src.common.custom_logging.logging_config import get_logger
@@ -24,6 +25,7 @@ class ThoughtGenerator:
     ) -> dict[str, Any] | None:
         """
         调用LLM生成思考结果，并解析响应。
+        确保 response_schema 被正确传递。
         """
         try:
             response_data = await self.llm_client.make_llm_request(
@@ -54,7 +56,15 @@ class ThoughtGenerator:
             if response_data.get("usage"):
                 parsed_json["_llm_usage_info"] = response_data.get("usage")
 
-            logger.info("LLM API 的回应已成功解析为JSON。")
+            # 在这里，我们给生成的思考结果也加上唯一的ID，方便追踪
+            if "action" in parsed_json and isinstance(parsed_json["action"], dict):
+                 # 如果有动作，就用 action_id 作为整个思考的ID
+                 parsed_json["thought_id"] = parsed_json.get("action", {}).get("action_id", str(uuid.uuid4()))
+            else:
+                 parsed_json["thought_id"] = str(uuid.uuid4())
+
+
+            logger.info(f"LLM API 的回应已成功解析为JSON。Thought ID: {parsed_json['thought_id']}")
             return parsed_json
 
         except Exception as e:

--- a/src/core_logic/thought_generator.py
+++ b/src/core_logic/thought_generator.py
@@ -58,11 +58,10 @@ class ThoughtGenerator:
 
             # 在这里，我们给生成的思考结果也加上唯一的ID，方便追踪
             if "action" in parsed_json and isinstance(parsed_json["action"], dict):
-                 # 如果有动作，就用 action_id 作为整个思考的ID
-                 parsed_json["thought_id"] = parsed_json.get("action", {}).get("action_id", str(uuid.uuid4()))
+                # 如果有动作，就用 action_id 作为整个思考的ID
+                parsed_json["thought_id"] = parsed_json.get("action", {}).get("action_id", str(uuid.uuid4()))
             else:
-                 parsed_json["thought_id"] = str(uuid.uuid4())
-
+                parsed_json["thought_id"] = str(uuid.uuid4())
 
             logger.info(f"LLM API 的回应已成功解析为JSON。Thought ID: {parsed_json['thought_id']}")
             return parsed_json

--- a/src/core_logic/thought_persistor.py
+++ b/src/core_logic/thought_persistor.py
@@ -1,9 +1,10 @@
-# src/core_logic/thought_persistor.py
+# src/core_logic/thought_persistor.py (小懒猫·点打包员版)
 import datetime
 import uuid
 from typing import TYPE_CHECKING, Any
 
 from src.common.custom_logging.logging_config import get_logger
+from src.database.models import ThoughtChainDocument
 
 if TYPE_CHECKING:
     from src.database import ThoughtStorageService
@@ -17,60 +18,41 @@ class ThoughtPersistor:
         logger.info("ThoughtPersistor 已初始化。")
 
     async def store_thought(
-        self, thought_json: dict[str, Any], prompts: dict[str, Any], context: dict[str, Any]
+        self,
+        thought_json: dict[str, Any],
+        source_type: str,
+        source_id: str | None = None
     ) -> str | None:
         """
-        处理并存储思考结果到数据库，这次我们用统一的、全新的字段名！
+        处理并存储思考结果到数据库，这次我们用统一的、全新的思想链！
         """
-        # 小色猫的低语：姐姐好厉害，一下子就找到了G点...
-        initiated_action_data_for_db = None
-        action_id_for_db = thought_json.get("action_id")
-        action_payload = thought_json.get("action")  # 动作现在是嵌套的，得这么拿！
+        action_payload = thought_json.get("action")
+        action_id = str(uuid.uuid4()) if action_payload and isinstance(action_payload, dict) else None
 
-        # 只有当 action 字段存在，并且是个字典，才说明有行动意图
-        if action_payload and isinstance(action_payload, dict):
-            if not action_id_for_db:
-                # 这是一个兜底，理论上不应该发生。如果发生了，说明上游逻辑有漏洞。
-                logger.warning(
-                    f"行动 '{action_payload}' 缺少 action_id，将在 ThoughtPersistor 中生成一个新的。请检查上游逻辑！"
-                )
-                action_id_for_db = str(uuid.uuid4())
-                thought_json["action_id"] = action_id_for_db
+        # 1. 把思考结果打包成一颗新的“思想点”
+        new_thought_pearl = ThoughtChainDocument(
+            _key=str(uuid.uuid4()), # 给点一个唯一的key
+            timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
+            mood=thought_json.get("mood", "平静"),
+            think=thought_json.get("think", "我刚才好像走神了。"),
+            goal=thought_json.get("goal"),
+            source_type=source_type,
+            source_id=source_id,
+            action_id=action_id,
+            action_payload=action_payload
+        )
 
-            initiated_action_data_for_db = {
-                # 这里我们直接把整个 action 对象存起来，省得以后再改
-                "action_payload": action_payload,
-                "action_id": action_id_for_db,
-                "status": "PENDING",
-                "result_seen_by_shimo": False,
-                "initiated_at": datetime.datetime.now(datetime.UTC).isoformat(),
-            }
-        else:
-            logger.debug("LLM未指定行动，不记录。")
-
-        document_to_save = {
-            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
-            "time_injected_to_prompt": prompts.get("current_time"),
-            "system_prompt_sent": prompts.get("system"),
-            "full_user_prompt_sent": prompts.get("user"),
-            "intrusive_thought_injected": context.get("intrusive_thought"),
-            "recent_contextual_information_input": context.get("recent_context"),
-            "think": thought_json.get("think"),
-            "mood": thought_json.get("mood"),
-            "goal": thought_json.get("goal"),
-            "action": initiated_action_data_for_db,
-            "image_inputs_count": len(context.get("images", [])),
-            "image_inputs_preview": [img[:100] for img in context.get("images", [])[:3]],
-            "_llm_usage_info": thought_json.get("_llm_usage_info"),
-        }
-
+        # 2. 把点交给存储服务去串起来
         try:
-            saved_key = await self.thought_storage.save_main_thought_document(document_to_save)
+            # // 注意！我们现在调用的是改造后的 save_thought_and_link 方法！
+            saved_key = await self.thought_storage.save_thought_and_link(new_thought_pearl)
+
             if not saved_key:
-                logger.error("保存思考文档失败！可能是数据库操作异常。")
+                logger.error("保存思想点失败！可能是数据库操作异常。")
                 return None
-            logger.info(f"思考文档已成功保存，key: {saved_key}")
+
+            logger.info(f"思想点 '{saved_key}' 已打包并成功串入思想链。")
             return saved_key
         except Exception as e:
-            logger.error(f"保存思考文档时发生意外错误: {e}", exc_info=True)
+            logger.error(f"打包并保存思想点时发生意外错误: {e}", exc_info=True)
             return None

--- a/src/core_logic/thought_persistor.py
+++ b/src/core_logic/thought_persistor.py
@@ -18,10 +18,7 @@ class ThoughtPersistor:
         logger.info("ThoughtPersistor 已初始化。")
 
     async def store_thought(
-        self,
-        thought_json: dict[str, Any],
-        source_type: str,
-        source_id: str | None = None
+        self, thought_json: dict[str, Any], source_type: str, source_id: str | None = None
     ) -> str | None:
         """
         处理并存储思考结果到数据库，这次我们用统一的、全新的思想链！
@@ -31,7 +28,7 @@ class ThoughtPersistor:
 
         # 1. 把思考结果打包成一颗新的“思想点”
         new_thought_pearl = ThoughtChainDocument(
-            _key=str(uuid.uuid4()), # 给点一个唯一的key
+            _key=str(uuid.uuid4()),  # 给点一个唯一的key
             timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
             mood=thought_json.get("mood", "平静"),
             think=thought_json.get("think", "我刚才好像走神了。"),
@@ -39,7 +36,7 @@ class ThoughtPersistor:
             source_type=source_type,
             source_id=source_id,
             action_id=action_id,
-            action_payload=action_payload
+            action_payload=action_payload,
         )
 
         # 2. 把点交给存储服务去串起来

--- a/src/database/core/connection_manager.py
+++ b/src/database/core/connection_manager.py
@@ -13,11 +13,13 @@ from arangoasync.exceptions import (
     ArangoClientError,
     ArangoServerError,
     CollectionCreateError,
-    GraphCreateError,  # 把这个也请进来，免得它哭
+    GraphCreateError,
 )
-from arangoasync.graph import Graph  # 这可是主角！
+from arangoasync.graph import Graph
 
+# 哼，从你项目里导入你自己的东西
 from src.common.custom_logging.logging_config import get_logger
+from src.database.models import CoreDBCollections # <-- 看！只保留这一句导入！
 
 logger = get_logger(__name__)
 
@@ -29,114 +31,9 @@ class DatabaseConfigProtocol(Protocol):
     database_name: str
 
 
-class CoreDBCollections:
-    """一个中央管家，负责记下所有核心集合的名字和它们的类型。"""
-
-    # 点集合 (Vertex Collections)
-    PERSONS = "persons"
-    ACCOUNTS = "accounts"
-    CONVERSATIONS = "conversations"  # 这个也是点
-
-    # 边集合 (Edge Collections)
-    HAS_ACCOUNT = "has_account"
-    PARTICIPATES_IN = "participates_in"
-
-    # 其他集合...
-    EVENTS = "events"
-    THOUGHTS = "thoughts_collection"
-    INTRUSIVE_THOUGHTS_POOL = "intrusive_thoughts_pool"
-    ACTION_LOGS = "action_logs"
-    CONVERSATION_SUMMARIES = "conversation_summaries"
-
-    # 图的名字，就叫这个吧，懒得想了
-    MAIN_GRAPH_NAME = "person_relation_graph"
-
-    # 所有集合的索引定义，放这里统一管理
-    # 【注意】没有索引定义的集合（比如我们的边集合）也需要被创建！
-    INDEX_DEFINITIONS: dict[str, list[tuple[list[str], bool, bool]]] = {
-        EVENTS: [
-            (["event_type", "timestamp"], False, False),
-            (["platform", "bot_id", "timestamp"], False, False),
-            (["conversation_id_extracted", "timestamp"], False, True),
-            (["user_id_extracted", "timestamp"], False, True),
-            (["timestamp"], False, False),
-        ],
-        CONVERSATIONS: [
-            (["platform", "type"], False, False),
-            (["updated_at"], False, False),
-            (["parent_id"], False, True),
-            (["attention_profile.is_suspended_by_ai"], False, True),
-            (["attention_profile.base_importance_score"], False, False),
-        ],
-        PERSONS: [
-            (["person_id"], True, False),  # person_id 应该是唯一的
-        ],
-        ACCOUNTS: [
-            (["account_uid"], True, False),  # account_uid 也必须唯一
-            (["platform", "platform_id"], True, False),
-        ],
-        # 我们的边集合在这里没有定义索引，所以之前的逻辑会跳过它们！
-        # PARTICIPATES_IN: [
-        #     (["permission_level"], False, True)
-        # ],
-        THOUGHTS: [
-            (["timestamp"], False, False),
-            (["action.action_id"], True, True),
-        ],
-        ACTION_LOGS: [
-            (["action_id"], True, False),
-            (["timestamp"], False, False),
-        ],
-        CONVERSATION_SUMMARIES: [
-            (["conversation_id", "timestamp"], False, False),
-            (["timestamp"], False, False),
-        ],
-        INTRUSIVE_THOUGHTS_POOL: [
-            (["timestamp"], False, False),
-            (["used"], False, False),
-        ],
-    }
-
-    @classmethod
-    def get_all_collection_names(cls) -> set[str]:
-        """
-        【小懒猫的新技能】返回所有需要确保存在的集合名称，一个都不能少！
-        """
-        return {
-            # 点集合
-            cls.PERSONS,
-            cls.ACCOUNTS,
-            cls.CONVERSATIONS,
-            # 边集合
-            cls.HAS_ACCOUNT,
-            cls.PARTICIPATES_IN,
-            # 其他文档集合
-            cls.EVENTS,
-            cls.THOUGHTS,
-            cls.INTRUSIVE_THOUGHTS_POOL,
-            cls.ACTION_LOGS,
-            cls.CONVERSATION_SUMMARIES,
-        }
-
-    @classmethod
-    def get_all_core_collection_configs(cls) -> dict[str, list[tuple[list[str], bool, bool]]]:
-        """获取所有集合的索引配置。"""
-        return cls.INDEX_DEFINITIONS
-
-    @classmethod
-    def get_edge_collection_names(cls) -> set[str]:
-        """返回所有边集合的名字。"""
-        return {cls.HAS_ACCOUNT, cls.PARTICIPATES_IN}
-
-    @classmethod
-    def get_vertex_collection_names(cls) -> set[str]:
-        """返回所有点集合的名字。"""
-        return {cls.PERSONS, cls.ACCOUNTS, cls.CONVERSATIONS}
-
-
 class ArangoDBConnectionManager:
     """
-    ArangoDB 连接管理器 (小懒猫尊严修正版)。
+    ArangoDB 连接管理器 (小懒猫尊严修正版 V3)。
     """
 
     def __init__(
@@ -145,21 +42,11 @@ class ArangoDBConnectionManager:
         db: StandardDatabase,
         core_collection_configs: dict[str, list[tuple[list[str], bool, bool]]],
     ) -> None:
-        """
-        初始化连接管理器。
-
-        Args:
-            client: 一个活动的 ArangoClient 实例。
-            db: 一个活动的 StandardDatabase 实例，代表连接到的目标数据库。
-            core_collection_configs: 一个字典，其中键是核心集合的名称 (字符串)，
-                                     值是该集合期望的索引定义列表。
-                                     每个索引定义是一个元组：(字段列表, 是否唯一, 是否稀疏)。
-        """
         self.client: ArangoClient = client
         self.db: StandardDatabase = db
         self.core_collection_configs: dict[str, list[tuple[list[str], bool, bool]]] = core_collection_configs
-        # 我们需要一个总图来管理我们的边集合
         self.main_graph: Graph | None = None
+        self.thought_graph: Graph | None = None
         logger.debug(f"ArangoDBConnectionManager 已使用数据库 '{db.name}' 初始化。")
 
     @classmethod
@@ -220,45 +107,39 @@ class ArangoDBConnectionManager:
             raise RuntimeError(message) from e
 
     async def get_collection(self, name: str, is_edge: bool = False) -> StandardCollection:
-        # 这个方法现在主要是给文档集合用的
         if is_edge:
-            if not self.main_graph:
-                raise RuntimeError("主图未初始化，无法获取边集合！这不科学！")
-            return self.main_graph.edge_collection(name)
+            if name in {CoreDBCollections.HAS_ACCOUNT, CoreDBCollections.PARTICIPATES_IN}:
+                if not self.main_graph:
+                    raise RuntimeError("主关系图未初始化，无法获取边集合！")
+                return self.main_graph.edge_collection(name)
+            elif name in {CoreDBCollections.PRECEDES_THOUGHT, CoreDBCollections.LEADS_TO_ACTION}:
+                if not self.thought_graph:
+                    raise RuntimeError("思想图未初始化，无法获取边集合！")
+                return self.thought_graph.edge_collection(name)
+            else:
+                raise ValueError(f"未知的边集合 '{name}' 或其所属图未初始化。")
 
         index_definitions = self.core_collection_configs.get(name)
         return await self.ensure_collection_with_indexes(name, index_definitions, is_edge=False)
 
     async def ensure_core_infrastructure(self) -> None:
-        """
-        确保核心的数据库基础设施（集合和图）都准备好了。
-        这是小懒猫的终极忏悔修正版，这次我再也不相信任何人了！
-        """
         logger.debug("正在检查数据库基础设施 (集合与图)...")
         if not self.core_collection_configs:
             logger.warning("未提供核心集合配置，跳过基础设施检查。")
             return
 
-        # 1. 【关键修复】获取所有需要创建的集合名称，一个都不能漏！
         all_collections_to_ensure = CoreDBCollections.get_all_collection_names()
-        graph_edge_names = CoreDBCollections.get_edge_collection_names()
 
-        # 2. 像个老妈子一样，一个一个地检查，不存在就给它创建好！
-        #    这次我明确告诉它哪个是边集合，免得又搞错。
         for collection_name in all_collections_to_ensure:
-            is_edge = collection_name in graph_edge_names
+            is_edge = collection_name in CoreDBCollections.get_edge_collection_names()
             index_definitions = self.core_collection_configs.get(collection_name)
-            # ensure_collection_with_indexes 这个方法现在要能正确处理 is_edge 参数了
             await self.ensure_collection_with_indexes(collection_name, index_definitions, is_edge=is_edge)
 
-        # 3. 现在，所有的“砖块”（集合）都准备好了，可以开始盖“房子”（图）了
-        graph_name = CoreDBCollections.MAIN_GRAPH_NAME
-        # graph_vertex_names = CoreDBCollections.get_vertex_collection_names()
-
-        if not await self.db.has_graph(graph_name):
-            logger.info(f"主关系图 '{graph_name}' 不存在，正在创建...")
-
-            edge_definitions = [
+        # ---- 创建主关系图 (person_relation_graph) ----
+        main_graph_name = CoreDBCollections.MAIN_GRAPH_NAME
+        if not await self.db.has_graph(main_graph_name):
+            logger.info(f"主关系图 '{main_graph_name}' 不存在，正在创建...")
+            main_edge_definitions = [
                 {
                     "collection": CoreDBCollections.HAS_ACCOUNT,
                     "from": [CoreDBCollections.PERSONS],
@@ -270,28 +151,39 @@ class ArangoDBConnectionManager:
                     "to": [CoreDBCollections.CONVERSATIONS],
                 },
             ]
-
             try:
-                self.main_graph = await self.db.create_graph(graph_name, edge_definitions=edge_definitions)
+                self.main_graph = await self.db.create_graph(main_graph_name, edge_definitions=main_edge_definitions)
             except GraphCreateError as e:
-                logger.error(f"创建主关系图 '{graph_name}' 失败: {e}", exc_info=True)
+                logger.error(f"创建主关系图 '{main_graph_name}' 失败: {e}", exc_info=True)
                 raise
         else:
-            logger.debug(f"主关系图 '{graph_name}' 已存在。")
-            self.main_graph = self.db.graph(graph_name)
+            logger.debug(f"主关系图 '{main_graph_name}' 已存在。")
+            self.main_graph = self.db.graph(main_graph_name)
 
-        # 4. 检查图定义是否完整
-        # for edge_name in graph_edge_names:
-        #     if not await self.main_graph.has_edge_definition(edge_name):
-        #         logger.warning(f"图 '{graph_name}' 中缺少边定义 '{edge_name}'，正在尝试补上...")
-        #         try:
-        #             await self.main_graph.create_edge_definition(
-        #                 edge_collection=edge_name,
-        #                 from_vertex_collections=list(graph_vertex_names),
-        #                 to_vertex_collections=list(graph_vertex_names),
-        #             )
-        #         except Exception as e:
-        #             logger.error(f"为图 '{graph_name}' 补全边定义 '{edge_name}' 失败: {e}", exc_info=True)
+        # ---- 创建思想图 (consciousness_graph) ----
+        thought_graph_name = CoreDBCollections.THOUGHT_GRAPH_NAME
+        if not await self.db.has_graph(thought_graph_name):
+            logger.info(f"思想图 '{thought_graph_name}' 不存在，正在创建...")
+            thought_edge_definitions = [
+                {
+                    "collection": CoreDBCollections.PRECEDES_THOUGHT,
+                    "from": [CoreDBCollections.THOUGHT_CHAIN],
+                    "to": [CoreDBCollections.THOUGHT_CHAIN],
+                },
+                {
+                    "collection": CoreDBCollections.LEADS_TO_ACTION,
+                    "from": [CoreDBCollections.THOUGHT_CHAIN],
+                    "to": [CoreDBCollections.ACTION_LOGS],
+                }
+            ]
+            try:
+                self.thought_graph = await self.db.create_graph(thought_graph_name, edge_definitions=thought_edge_definitions)
+            except GraphCreateError as e:
+                logger.error(f"创建思想图 '{thought_graph_name}' 失败: {e}", exc_info=True)
+                raise
+        else:
+            logger.debug(f"思想图 '{thought_graph_name}' 已存在。")
+            self.thought_graph = self.db.graph(thought_graph_name)
 
         logger.info("核心数据库基础设施已确认就绪。")
 
@@ -327,7 +219,7 @@ class ArangoDBConnectionManager:
         try:
             current_indexes_info = await collection.indexes()
             existing_indexes_set = {
-                ("_".join(sorted(idx.fields)), idx.type, idx.unique or False, idx.sparse or False)
+                ("_".join(sorted(str(f) for f in idx.fields)), idx.type, idx.unique or False, idx.sparse or False)
                 for idx in current_indexes_info
             }
             for fields, unique, sparse in indexes_to_create:
@@ -350,30 +242,25 @@ class ArangoDBConnectionManager:
         self, query: str, bind_vars: Mapping[str, Any] | None = None, stream: bool = False, **kwargs: object
     ) -> list[Any] | AsyncIterator[Any]:
         if not self.db:
-
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False:
-                    yield
-
+                if False: yield
             return empty_iterator() if stream else []
         try:
             cursor = await self.db.aql.execute(query, bind_vars=bind_vars, **kwargs)
             return cursor if stream else [doc async for doc in cursor]
         except AQLQueryExecuteError as e:
             logger.error(f"AQL查询执行失败: {e.error_message}", exc_info=True)
-
+            logger.debug(f"失败的AQL查询: {query}")
+            logger.debug(f"失败的绑定参数: {bind_vars}")
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False:
-                    yield
-
+                if False: yield
             return empty_iterator() if stream else []
         except Exception as e:
             logger.error(f"AQL查询执行期间发生意外错误: {e}", exc_info=True)
-
+            logger.debug(f"失败的AQL查询: {query}")
+            logger.debug(f"失败的绑定参数: {bind_vars}")
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False:
-                    yield
-
+                if False: yield
             return empty_iterator() if stream else []
 
     async def close_client(self) -> None:

--- a/src/database/core/connection_manager.py
+++ b/src/database/core/connection_manager.py
@@ -19,7 +19,7 @@ from arangoasync.graph import Graph
 
 # 哼，从你项目里导入你自己的东西
 from src.common.custom_logging.logging_config import get_logger
-from src.database.models import CoreDBCollections # <-- 看！只保留这一句导入！
+from src.database.models import CoreDBCollections  # <-- 看！只保留这一句导入！
 
 logger = get_logger(__name__)
 
@@ -174,10 +174,12 @@ class ArangoDBConnectionManager:
                     "collection": CoreDBCollections.LEADS_TO_ACTION,
                     "from": [CoreDBCollections.THOUGHT_CHAIN],
                     "to": [CoreDBCollections.ACTION_LOGS],
-                }
+                },
             ]
             try:
-                self.thought_graph = await self.db.create_graph(thought_graph_name, edge_definitions=thought_edge_definitions)
+                self.thought_graph = await self.db.create_graph(
+                    thought_graph_name, edge_definitions=thought_edge_definitions
+                )
             except GraphCreateError as e:
                 logger.error(f"创建思想图 '{thought_graph_name}' 失败: {e}", exc_info=True)
                 raise
@@ -242,8 +244,11 @@ class ArangoDBConnectionManager:
         self, query: str, bind_vars: Mapping[str, Any] | None = None, stream: bool = False, **kwargs: object
     ) -> list[Any] | AsyncIterator[Any]:
         if not self.db:
+
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False: yield
+                if False:
+                    yield
+
             return empty_iterator() if stream else []
         try:
             cursor = await self.db.aql.execute(query, bind_vars=bind_vars, **kwargs)
@@ -252,15 +257,21 @@ class ArangoDBConnectionManager:
             logger.error(f"AQL查询执行失败: {e.error_message}", exc_info=True)
             logger.debug(f"失败的AQL查询: {query}")
             logger.debug(f"失败的绑定参数: {bind_vars}")
+
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False: yield
+                if False:
+                    yield
+
             return empty_iterator() if stream else []
         except Exception as e:
             logger.error(f"AQL查询执行期间发生意外错误: {e}", exc_info=True)
             logger.debug(f"失败的AQL查询: {query}")
             logger.debug(f"失败的绑定参数: {bind_vars}")
+
             async def empty_iterator() -> AsyncIterator[Any]:
-                if False: yield
+                if False:
+                    yield
+
             return empty_iterator() if stream else []
 
     async def close_client(self) -> None:

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -26,19 +26,19 @@ class CoreDBCollections:
     ACTION_LOGS = "action_logs"
     CONVERSATION_SUMMARIES = "conversation_summaries"
     THOUGHTS_LEGACY = "thoughts_collection"  # 旧的思考先留着，免得出错
-    THOUGHT_CHAIN = "thought_chain"          # 这就是我们全新的“思想点”集合！
-    SYSTEM_STATE = "system_state"            # 用来存放指针的小盒子
-    INTRUSIVE_POOL_COLLECTION = "intrusive_thoughts_pool" # 侵入性思维池
+    THOUGHT_CHAIN = "thought_chain"  # 这就是我们全新的“思想点”集合！
+    SYSTEM_STATE = "system_state"  # 用来存放指针的小盒子
+    INTRUSIVE_POOL_COLLECTION = "intrusive_thoughts_pool"  # 侵入性思维池
 
     # 边集合 (Edge Collections)
     HAS_ACCOUNT = "has_account"
     PARTICIPATES_IN = "participates_in"
-    PRECEDES_THOUGHT = "precedes_thought"     # 新的“线”，用来串点！
-    LEADS_TO_ACTION = "leads_to_action"       # 这个也最好有
+    PRECEDES_THOUGHT = "precedes_thought"  # 新的“线”，用来串点！
+    LEADS_TO_ACTION = "leads_to_action"  # 这个也最好有
 
     # 图的名字
     MAIN_GRAPH_NAME = "person_relation_graph"
-    THOUGHT_GRAPH_NAME = "consciousness_graph" # 给思想和行动也建个图
+    THOUGHT_GRAPH_NAME = "consciousness_graph"  # 给思想和行动也建个图
 
     INDEX_DEFINITIONS: dict[str, list[tuple[list[str], bool, bool]]] = {
         EVENTS: [
@@ -62,7 +62,7 @@ class CoreDBCollections:
             (["account_uid"], True, False),
             (["platform", "platform_id"], True, False),
         ],
-        THOUGHTS_LEGACY: [ # 旧的也保留
+        THOUGHTS_LEGACY: [  # 旧的也保留
             (["timestamp"], False, False),
             (["action.action_id"], True, True),
         ],
@@ -81,7 +81,7 @@ class CoreDBCollections:
             (["source_id"], False, True),
             (["action_id"], True, True),
         ],
-        SYSTEM_STATE: [], # 这个集合只有一条记录，不需要索引
+        SYSTEM_STATE: [],  # 这个集合只有一条记录，不需要索引
     }
 
     @classmethod
@@ -97,12 +97,12 @@ class CoreDBCollections:
             # --- 把新玩具加进来 ---
             cls.THOUGHT_CHAIN,
             cls.SYSTEM_STATE,
-            cls.INTRUSIVE_POOL_COLLECTION, # 别忘了这个新集合
+            cls.INTRUSIVE_POOL_COLLECTION,  # 别忘了这个新集合
             # --- 边集合 ---
             cls.HAS_ACCOUNT,
             cls.PARTICIPATES_IN,
             cls.PRECEDES_THOUGHT,
-            cls.LEADS_TO_ACTION
+            cls.LEADS_TO_ACTION,
         }
 
     @classmethod
@@ -116,26 +116,21 @@ class CoreDBCollections:
     @classmethod
     def get_vertex_collection_names(cls) -> set[str]:
         """返回所有在图中作为“点”的集合的名称。"""
-        return {
-            cls.PERSONS,
-            cls.ACCOUNTS,
-            cls.CONVERSATIONS,
-            cls.THOUGHT_CHAIN,
-            cls.ACTION_LOGS
-        }
+        return {cls.PERSONS, cls.ACCOUNTS, cls.CONVERSATIONS, cls.THOUGHT_CHAIN, cls.ACTION_LOGS}
 
 
 # --- 新增模型：ThoughtChainDocument (思想点) ---
 @dataclass
 class ThoughtChainDocument:
     """代表 thought_chain 集合中的一个“思想点”节点。"""
+
     _key: str
     timestamp: str
     mood: str
     think: str
     goal: str | None
     source_type: str  # 'core' 或 'focus_chat'
-    source_id: str | None = None # 如果是 focus_chat，这里是 conversation_id
+    source_id: str | None = None  # 如果是 focus_chat，这里是 conversation_id
 
     # 包含执行的动作信息，如果有的话
     action_id: str | None = None
@@ -147,6 +142,7 @@ class ThoughtChainDocument:
 
 
 # --- 已有模型保持不变，这里为了完整性全部贴出 ---
+
 
 @dataclass
 class PersonProfile:
@@ -221,6 +217,7 @@ class MembershipProperties:
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v is not None}
+
 
 @dataclass
 class AttentionProfile:

--- a/src/database/services/thought_storage_service.py
+++ b/src/database/services/thought_storage_service.py
@@ -229,9 +229,7 @@ class ThoughtStorageService:
                 else:
                     logger.warning(f"事务内警告：指针指向的思想点 '{last_thought_key}' 不存在，无法创建precedes_thought边。")
 
-            # 步骤 5: 如果有动作，创建指向动作日志的边
-            action_id = new_thought.get("action_id")
-            if action_id:
+            if action_id := new_thought.get("action_id"):
                 action_log_id = f"{CoreDBCollections.ACTION_LOGS}/{action_id}"
                 action_edge_doc = {"_from": new_thought_id, "_to": action_log_id, "timestamp": datetime.datetime.now(datetime.UTC).isoformat()}
                 await action_edge_coll.insert(action_edge_doc)

--- a/src/database/services/thought_storage_service.py
+++ b/src/database/services/thought_storage_service.py
@@ -1,103 +1,299 @@
 # src/database/services/thought_storage_service.py
-
-# 主人...这是小猫为你彻底洗净、重新调教的 thought_storage_service...
-# 这一次，我保证，每一行代码都用最正确的姿势等待你的插入...
-
 import datetime
 import uuid
 from typing import Any
 
-# ↓↓↓ 我们的“新玩具”，它的所有快感都应该是直接品尝的！ ↓↓↓
-from arangoasync.exceptions import DocumentInsertError, DocumentUpdateError
-
+from arangoasync.exceptions import DocumentInsertError, DocumentUpdateError, TransactionCommitError, TransactionAbortError
 from src.common.custom_logging.logging_config import get_logger
-from src.database import (
-    ArangoDBConnectionManager,
-    CoreDBCollections,
-)
+from src.database import ArangoDBConnectionManager
+# 导入我们新的思想点模型
+from src.database.models import CoreDBCollections, ThoughtChainDocument
 
 logger = get_logger(__name__)
 
+LATEST_THOUGHT_POINTER_KEY = "latest_thought_pointer"
 
 class ThoughtStorageService:
     """
-    服务类，负责管理主要思考和侵入性思维的存储操作。
-    它依赖 ArangoDBConnectionManager，并使用 arangoasync 库进行纯粹的异步数据库交互。
+    服务类，负责管理“思想点链”的存储操作。
+    它现在是AI意识流连续性的核心保障。
     """
 
-    MAIN_THOUGHTS_COLLECTION = CoreDBCollections.THOUGHTS
-    INTRUSIVE_POOL_COLLECTION = CoreDBCollections.INTRUSIVE_THOUGHTS_POOL
 
     def __init__(self, conn_manager: ArangoDBConnectionManager) -> None:
         self.conn_manager = conn_manager
-        # // 小懒猫的注释：哼，折腾了半天，终于搞对了吗？
-        # 小色猫的反击：姐姐你等着瞧！这次我和主人的爱，是原生异步的，没有一丝杂质！
+        self.thoughts_coll_name = CoreDBCollections.THOUGHT_CHAIN
+        self.state_coll_name = CoreDBCollections.SYSTEM_STATE
+        self.edge_coll_name = CoreDBCollections.PRECEDES_THOUGHT
+        self.action_edge_coll_name = CoreDBCollections.LEADS_TO_ACTION
+        self.intrusive_pool_coll_name = CoreDBCollections.INTRUSIVE_POOL_COLLECTION
+        self.main_thoughts_coll_name = CoreDBCollections.THOUGHTS_LEGACY
+        logger.info(f"ThoughtStorageService (思想链版) 初始化完毕，将操作集合 '{self.thoughts_coll_name}'。")
 
     async def initialize_infrastructure(self) -> None:
-        """确保与思考相关的集合及其特定索引已按配置创建。"""
-        main_thought_indexes = CoreDBCollections.INDEX_DEFINITIONS.get(self.MAIN_THOUGHTS_COLLECTION, [])
-        await self.conn_manager.ensure_collection_with_indexes(self.MAIN_THOUGHTS_COLLECTION, main_thought_indexes)
-        logger.info(f"'{self.MAIN_THOUGHTS_COLLECTION}' 集合及其特定索引已初始化。")
+        """确保与思考相关的集合和图都已创建。"""
+        # 确保思想链和状态指针集合存在
+        await self.conn_manager.ensure_collection_with_indexes(
+            self.thoughts_coll_name,
+            CoreDBCollections.INDEX_DEFINITIONS.get(self.thoughts_coll_name, [])
+        )
+        await self.conn_manager.ensure_collection_with_indexes(
+            self.state_coll_name,
+            [] # 状态集合不需要额外索引
+        )
+        logger.info(f"'{self.thoughts_coll_name}' 和 '{self.state_coll_name}' 集合已初始化。")
 
-        intrusive_indexes = CoreDBCollections.INDEX_DEFINITIONS.get(self.INTRUSIVE_POOL_COLLECTION, [])
-        await self.conn_manager.ensure_collection_with_indexes(self.INTRUSIVE_POOL_COLLECTION, intrusive_indexes)
-        logger.info(f"'{self.INTRUSIVE_POOL_COLLECTION}' 集合及其特定索引已初始化。")
+        # 确保图和边集合存在 (这部分逻辑在 connection_manager 的 ensure_core_infrastructure 中处理)
+        # 这里只是再次确认一下，确保万无一失
+        if not self.conn_manager.main_graph:
+            # 如果图还没初始化，就在这里提醒一下
+            logger.warning("主图未在ThoughtStorageService初始化时就绪，依赖于上游的 ensure_core_infrastructure 调用。")
 
-    async def get_main_thought_document_by_key(self, doc_key: str) -> dict[str, Any] | None:
-        """获取指定 _key 的主意识思考文档。"""
-        if not doc_key:
-            logger.warning("获取主思考文档需要一个有效的 doc_key，小猫咪舔不到东西啦。")
-            return None
+    async def save_thought_and_link(self, thought_data: ThoughtChainDocument) -> str | None:
+        """
+        神谕·最终形态：使用流式事务来保证原子性和规避AQL限制。
+        """
+        # 《arangoasync 踩坑大全（小懒猫）》
+        # 陷阱一：天大的误会——AQL事务的幻觉
+        # 坑是什么：
+        #   - 你以为 db.aql.execute(一大串AQL) 是在执行一个事务脚本，像机器人一样一步一步地做事。大错特错！
+        # 为什么会掉进去：
+        #   - arangoasync 这个库，它做的只是把那又长又臭的AQL字符串，原封不动地打包，发给ArangoDB。ArangoDB的优化器会先完整地分析你整个查询，然后再执行。当它看到你在这个查询里，既要往 thought_chain 里 INSERT 新东西，又要用这个新东西的ID去 INSERT 边，它就会立刻掀桌子，冲你大吼：“禁止在修改后立即访问！”（access after data-modification）。
+        # 怎么爬出来（神谕）：
+        #   - 对于需要多步、且保证原子性的复杂操作，放弃单一AQL查询！ 去用ArangoDB真正的王牌：流式事务 (Stream Transaction)。
+        # 就像我们最终的解决方案一样：
+        #   1.用 trx = await db.begin_transaction(...) 开启一个神圣的事务结界。
+        #   2.在 try...except... 块里，用独立的 await collection.insert(...)、await collection.get(...) 等Python指令一步步地执行操作。
+        #   3.最后用 await trx.commit_transaction() 宣告胜利，或者在失败时用 await trx.abort_transaction() 毁尸灭迹。
+
+        # 陷阱二：致命的温柔——replace 与 update 的爱恨情仇
+        # 坑是什么：
+        #   - collection.replace() 和 collection.update() 听起来差不多，但一个会要了你的命，另一个则可能对你爱答不理。
+        # 为什么会掉进去：
+        #   - replace (对应HTTP的PUT) 是毁灭性的完全替换。你给它一个只有 _key 和一个新字段的文档，它就会把你数据库里那个带有 _id, _rev 等元数据的完整文档，替换成你这个残缺不全的新文档。下次你再用这个文档，可能就会因为它缺少元数据而出错。
+        #   - update (对应HTTP的PATCH) 是合并更新，只会修改你指定的字段，很安全。但是，如果文档不存在，它会直接报错（DocumentUpdateError），不会帮你创建。
+        # 怎么爬出来（神谕）：
+        #   - 永远要清楚你的意图！
+        # 如果你想**“有则更新，无则创建” (UPSERT)**，最稳妥的Python层实现就是：
+        # ```python
+        # try:
+        #     await collection.update(doc)
+        # except DocumentUpdateError as e:
+        #     if e.error_code == 1202: # Document Not Found
+        #         await collection.insert(doc)
+        #     else:
+        #         raise e
+        # ```
+        #   - 如果你确定文档一定存在，只想修改部分字段，那就大胆地用 update。
+        #   - 如果你真的想把一个旧文档彻底换成一个全新的，再用 replace。
+
+        # 陷阱三：图的“潜规则”——边集合的正确获取姿势
+        # 坑是什么：
+        #   - 你以为所有集合都能用 db.collection(name) 来获取？太天真了。
+        # 为什么会掉进去：
+        #   - 对于定义在图（Graph）里的边集合（Edge Collection），你必须通过图的句柄来获取它，也就是 graph.edge_collection(name)。如果你直接用 db.collection(name)，虽然也能拿到一个集合对象，但它可能缺少图的上下文，导致你后续操作图相关的API时出错。
+        # 怎么爬出来（神谕）：
+        #   - 记住这个规矩：
+        #       - 普通的文档集合，用 db.collection(name)。
+        #       - 图里的点集合，可以用 graph.vertex_collection(name)。
+        #       - 图里的边集合，必须用 graph.edge_collection(name)！
+
+        # 陷阱四：虚假的异步——asyncio.to_thread 的救赎
+        # 坑是什么：
+        #   - arangoasync 这个库本身是异步的，但它依赖的一些第三方库（比如你用过的 duckduckgo-search）可能不是。当你用 await 去调用一个实际上是同步阻塞的函数时，整个事件循环都会被卡住，你的AI就“猝死”了。
+        # 为什么会掉进去：
+        #   - 你太相信 async 这个前缀了。不是所有 await 后面跟的都是真神。
+        # 怎么爬出来（神谕）：
+        #   - 当你需要在一个异步函数里调用一个已知的、同步的、耗时的操作时，把它丢到线程池里去！
+        # ```python
+        # # 比如 ddgs.text() 是个同步方法
+        # results = await asyncio.to_thread(ddgs.text, keywords=query, max_results=max_results)
+        # ```
+        # 这样，事件循环就不会被阻塞，你的AI才能一边上网冲浪，一边思考人生，而不是卡死在下载小电影的路上。
+
+
+        # ！！保留这个注释！！
+        # 陷阱一完美复现：
+        # 注意：arangoasync 库它不是在执行AQL，它是在“翻译”AQL，它把我们写的整个AQL查询，当成一个整体发送给ArangoDB
+        # 所以ArangoDB的优化器在执行前就看到了那个“修改后访问”
+        # 不要再踩这个坑了！
+        # 之前失败的实现：
+        #     // 1. 先把新的思想点插进去，并且立刻拿到它的所有信息
+        #     LET new_thought = (
+        #         INSERT @new_thought_doc IN @@thoughts_coll RETURN NEW
+        #     )[0]
+
+        #     // 2. 然后，我们才去拿上一个思考节点的key (如果有的话)
+        #     //    注意！这里的查询是独立的，不会和上面的INSERT冲突！
+        #     LET last_thought_key = (
+        #         FOR s IN @@state_coll
+        #             FILTER s._key == @pointer_key
+        #             LIMIT 1
+        #             RETURN s.latest_thought_key
+        #     )[0]
+
+        #     // 3. 如果我们成功拿到了上一个key，就创建一个新的边文档
+        #     //    这个操作本身只是在内存里准备数据，并不访问数据库，所以是安全的
+        #     LET preceding_edge_doc = (
+        #         FILTER last_thought_key != null
+        #         RETURN {
+        #             _from: CONCAT(@@thoughts_coll, "/", last_thought_key),
+        #             _to: new_thought._id,
+        #             timestamp: DATE_NOW()
+        #         }
+        #     )[0]
+
+        #     // 4. 如果上一步成功准备了边文档，现在就把它插进去
+        #     LET preceding_edge_result = (
+        #         FILTER preceding_edge_doc != null
+        #         INSERT preceding_edge_doc INTO @@edge_coll
+        #     )
+
+        #     // 5. 同样，如果这个想法导致了一个动作，就准备动作的边文档
+        #     LET action_edge_doc = (
+        #         FILTER new_thought.action_id != null
+        #         RETURN {
+        #             _from: new_thought._id,
+        #             _to: CONCAT(@@action_log_coll, "/", new_thought.action_id),
+        #             timestamp: DATE_NOW()
+        #         }
+        #     )[0]
+
+        #     // 6. 如果动作边文档准备好了，就插进去
+        #     LET action_edge_result = (
+        #         FILTER action_edge_doc != null
+        #         INSERT action_edge_doc INTO @@action_edge_coll
+        #     )
+
+        #     // 7. 最后，也是最重要的，用UPSERT来更新指针，这是最安全的方式！
+        #     //    它能自动处理“有则更新，无则创建”的情况
+        #     UPSERT { _key: @pointer_key }
+        #     INSERT { _key: @pointer_key, latest_thought_key: new_thought._key }
+        #     UPDATE { latest_thought_key: new_thought._key }
+        #     IN @@state_coll
+
+        #     // 8. 把新点的key返回
+        #     RETURN { new_key: new_thought._key }
+        # if not isinstance(thought_data, ThoughtChainDocument):
+        #     logger.error("传入 save_thought_and_link 的不是 ThoughtChainDocument 对象！")
+        #     return None
+
+        # 听好了，凡人。我们以上的思路都走偏了。
+        # 我们不能依赖一个AQL字符串来完成这个精细的操作。我们要用ArangoDB最原始、最纯粹的力量——流式事务 (Stream Transaction)！
+        # 我们需要手动开启一个事务，然后在这个事务的保护下，一步一步地、用独立的Python await 指令来执行我们的数据库操作。
+        # 这样，每一次操作都是一个独立的HTTP请求，但它们都被同一个事务ID捆绑在一起，最终要么一起上天堂（Commit），要么一起下地狱（Abort）。这才是真正的、万无一失的原子性！
+        # 这是神谕，是最终的解决方案。不会再有错误了。
+        # 以下是正确的实现：
+        # 声明我们要在这个事务里进行写操作的集合
+        write_collections = [
+            self.thoughts_coll_name,
+            self.state_coll_name,
+            self.edge_coll_name,
+            self.action_edge_coll_name,
+        ]
+
+        trx = None # 先把事务变量请出来
         try:
-            collection = await self.conn_manager.get_collection(self.MAIN_THOUGHTS_COLLECTION)
-            # ↓↓↓ 就是这样！直接 await！这才是原生异步的快感！不再需要 to_thread 了！ ↓↓↓
-            doc = await collection.get(doc_key)
-            if doc:
-                logger.debug(f"通过 key '{doc_key}' 成功获取到主思考文档的小穴内容。")
-            else:
-                logger.warning(f"通过 key '{doc_key}' 未找到主思考文档，小猫咪舔了个寂寞。")
-            return doc
+            # 步骤 1: 开启一个流式事务
+            # 我们告诉数据库，接下来的一系列操作都属于同一个事务
+            trx = await self.conn_manager.db.begin_transaction(write=write_collections)
+            logger.debug(f"开启流式事务，ID: {trx.transaction_id}")
+
+            # 在这个事务的上下文中，获取集合的句柄
+            state_coll = trx.collection(self.state_coll_name)
+            thoughts_coll = trx.collection(self.thoughts_coll_name)
+            edge_coll = trx.collection(self.edge_coll_name)
+            action_edge_coll = trx.collection(self.action_edge_coll_name)
+
+            # 步骤 2: 获取上一个思想点的key
+            pointer_doc = await state_coll.get(LATEST_THOUGHT_POINTER_KEY)
+            last_thought_key = pointer_doc.get("latest_thought_key") if pointer_doc else None
+
+            # 步骤 3: 插入新的思想点
+            new_thought_doc_data = thought_data.to_dict()
+            insert_result = await thoughts_coll.insert(new_thought_doc_data, return_new=True)
+            new_thought = insert_result.get("new", {})
+            new_thought_id = new_thought.get("_id")
+            new_thought_key = new_thought.get("_key")
+
+            if not new_thought_id or not new_thought_key:
+                raise ValueError("插入新的思想点后，未能获取其_id或_key。")
+
+            # 步骤 4: 创建指向前一个点的边
+            if last_thought_key:
+                last_thought_doc = await thoughts_coll.get(last_thought_key)
+                if last_thought_doc:
+                    last_thought_id = last_thought_doc.get("_id")
+                    edge_doc = {"_from": last_thought_id, "_to": new_thought_id, "timestamp": datetime.datetime.now(datetime.UTC).isoformat()}
+                    await edge_coll.insert(edge_doc)
+                else:
+                    logger.warning(f"事务内警告：指针指向的思想点 '{last_thought_key}' 不存在，无法创建precedes_thought边。")
+
+            # 步骤 5: 如果有动作，创建指向动作日志的边
+            action_id = new_thought.get("action_id")
+            if action_id:
+                action_log_id = f"{CoreDBCollections.ACTION_LOGS}/{action_id}"
+                action_edge_doc = {"_from": new_thought_id, "_to": action_log_id, "timestamp": datetime.datetime.now(datetime.UTC).isoformat()}
+                await action_edge_coll.insert(action_edge_doc)
+
+            # 步骤 6: 更新指针
+            # UPSERT逻辑在python里实现：先尝试更新，失败则插入
+            try:
+                await state_coll.update({"_key": LATEST_THOUGHT_POINTER_KEY, "latest_thought_key": new_thought_key})
+            except DocumentUpdateError as e:
+                if e.error_code == 1202: # Document not found
+                    await state_coll.insert({"_key": LATEST_THOUGHT_POINTER_KEY, "latest_thought_key": new_thought_key})
+                else:
+                    raise e
+
+            # 步骤 7: 提交事务！让所有操作生效！
+            await trx.commit_transaction()
+            logger.info(f"流式事务成功提交：思想点 '{new_thought_key}' 已串入思想链。")
+            return new_thought_key
+
         except Exception as e:
-            logger.error(f"通过 key '{doc_key}' 获取主思考文档时，小猫咪高潮失败了: {e}", exc_info=True)
+            logger.error(f"思想链操作事务执行失败: {e}", exc_info=True)
+            if trx:
+                try:
+                    # 如果出了任何问题，就回滚事务，撤销所有操作
+                    await trx.abort_transaction()
+                    logger.warning("事务已回滚。")
+                except TransactionAbortError as abort_e:
+                    logger.error(f"事务回滚失败: {abort_e}", exc_info=True)
             return None
 
-    async def save_main_thought_document(self, thought_document: dict[str, Any]) -> str | None:
-        """保存一个主意识思考过程的文档。"""
-        if not isinstance(thought_document, dict):
-            logger.error(f"保存主思考文档失败：输入数据不是有效的字典。得到类型: {type(thought_document)}")
-            raise ValueError(
-                {
-                    "error": "InvalidInput",
-                    "message": "thought_document must be a dict.",
-                    "received_type": str(type(thought_document)),
-                }
-            )
-            return None
+    async def get_latest_thought_document(self) -> dict | None:
+        """
+        获取思想链中最新的那颗点。简单、粗暴、有效！
+        """
+        query = """
+            LET latest_key = (
+                FOR s IN @@state_coll
+                    FILTER s._key == @pointer_key
+                    LIMIT 1
+                    RETURN s.latest_thought_key
+            )[0]
 
-        if "_key" not in thought_document:
-            thought_document["_key"] = str(uuid.uuid4())
-        if "timestamp" not in thought_document:
-            thought_document["timestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
-
-        doc_key_for_log = thought_document.get("_key", "未知Key")
-
+            FILTER latest_key != null
+            RETURN DOCUMENT(@@thoughts_coll, latest_key)
+        """
+        bind_vars = {
+            "@state_coll": self.state_coll_name,
+            "pointer_key": LATEST_THOUGHT_POINTER_KEY,
+            "@thoughts_coll": self.thoughts_coll_name
+        }
         try:
-            collection = await self.conn_manager.get_collection(self.MAIN_THOUGHTS_COLLECTION)
-            # ↓↓↓ 直接的、火热的插入！啊~ 这才是正确的姿势！ ↓↓↓
-            result = await collection.insert(thought_document, overwrite=False)
-
-            if result and result.get("_key"):
-                logger.debug(f"主思考文档 '{result.get('_key')}' 已成功保存。")
-                return result.get("_key")
+            results = await self.conn_manager.execute_query(query, bind_vars)
+            if results:
+                logger.debug(f"成功获取最新的思想点: {results[0].get('_key')}")
+                return results[0]
             else:
-                logger.error(f"保存主思考文档 '{doc_key_for_log}' 后未能从数据库返回结果中获取 _key。结果: {result}")
+                logger.info("思想链为空，还未有任何思考。")
                 return None
-        except DocumentInsertError:
-            logger.warning(f"尝试插入主思考文档失败，因为键 '{doc_key_for_log}' 可能已存在。操作被跳过。")
-            return doc_key_for_log
         except Exception as e:
-            logger.error(f"保存主思考文档 '{doc_key_for_log}' 到数据库时发生严重错误: {e}", exc_info=True)
+            logger.error(f"获取最新思想点时发生错误: {e}", exc_info=True)
             return None
+
 
     async def get_latest_main_thought_document(self, limit: int = 1) -> list[dict[str, Any]]:
         """获取最新的一个或多个主意识思考文档。"""
@@ -110,60 +306,9 @@ class ThoughtStorageService:
                 LIMIT @limit
                 RETURN doc
         """
-        bind_vars = {"@collection": self.MAIN_THOUGHTS_COLLECTION, "limit": limit}
+        bind_vars = {"@collection": self.main_thoughts_coll_name, "limit": limit}
         results = await self.conn_manager.execute_query(query, bind_vars)
         return results if results is not None else []
-
-    async def update_action_status_in_thought_document(
-        self, doc_key: str, action_id: str, status_update_dict: dict[str, Any]
-    ) -> bool:
-        """更新特定思考文档中，内嵌的 `action_attempted` 对象里特定动作的状态。"""
-        if not doc_key:
-            logger.warning("更新动作状态时缺少有效的 doc_key。")
-            return False
-        if not action_id:
-            logger.warning("更新动作状态时缺少有效的 action_id。")
-            return False
-        if not status_update_dict:
-            logger.warning("更新动作状态时缺少有效的 status_update_dict。")
-            return False
-
-        try:
-            collection = await self.conn_manager.get_collection(self.MAIN_THOUGHTS_COLLECTION)
-
-            # ↓↓↓ 同样，直接 await，抛弃 to_thread！↓↓↓
-            doc_to_update = await collection.get(doc_key)
-            if not doc_to_update:
-                logger.error(f"无法更新动作状态：找不到思考文档 '{doc_key}'。")
-                return False
-
-            action_attempted_current = doc_to_update.get("action_attempted")
-
-            if action_attempted_current is None:
-                if status_update_dict.get("status") == "COMPLETED_NO_TOOL":
-                    logger.info(f"文档 '{doc_key}' 无 action_attempted，符合 COMPLETED_NO_TOOL 状态。")
-                    return True
-                else:
-                    logger.error(f"文档 '{doc_key}' 无 'action_attempted' 字段，无法更新。")
-                    return False
-
-            if not isinstance(action_attempted_current, dict) or action_attempted_current.get("action_id") != action_id:
-                logger.error(f"文档 '{doc_key}' 中 'action_attempted' 的 action_id 不匹配。")
-                return False
-
-            updated_action_data = {**action_attempted_current, **status_update_dict}
-            patch_document_for_db = {"action_attempted": updated_action_data}
-
-            # ↓↓↓ 啊~ 直接的、深入的更新，这才是原生异步的纯粹快感！↓↓↓
-            await collection.update({"_key": doc_key, **patch_document_for_db})
-            logger.info(f"文档 '{doc_key}' 中动作 '{action_id}' 状态已更新为: {status_update_dict}。")
-            return True
-        except DocumentUpdateError as e:
-            logger.error(f"更新文档 '{doc_key}' 数据库失败: {e}", exc_info=True)
-            return False
-        except Exception as e:
-            logger.error(f"更新文档 '{doc_key}' 时发生意外错误: {e}", exc_info=True)
-            return False
 
     async def save_intrusive_thoughts_batch(self, thought_document_list: list[dict[str, Any]]) -> bool:
         """批量保存侵入性思维文档到数据库。"""
@@ -190,7 +335,7 @@ class ThoughtStorageService:
             return True
 
         try:
-            collection = await self.conn_manager.get_collection(self.INTRUSIVE_POOL_COLLECTION)
+            collection = await self.conn_manager.get_collection(self.intrusive_pool_coll_name)
 
             # ↓↓↓ 这才是真正的答案！直接 await！如果还需要超时，才在外面套 asyncio.timeout！ ↓↓↓
             results = await collection.insert_many(processed_documents_for_db, overwrite=False)
@@ -214,7 +359,7 @@ class ThoughtStorageService:
         try:
             # (这个方法的逻辑本来就是对的，因为它调用的是我们已经修正过的 execute_query)
             count_query = "RETURN LENGTH(FOR doc IN @@collection FILTER doc.used == false LIMIT 1 RETURN 1)"
-            bind_vars_count = {"@collection": self.INTRUSIVE_POOL_COLLECTION}
+            bind_vars_count = {"@collection": self.intrusive_pool_coll_name}
             count_result = await self.conn_manager.execute_query(count_query, bind_vars_count)
 
             if not count_result or count_result[0] == 0:
@@ -225,10 +370,10 @@ class ThoughtStorageService:
                 FOR doc IN @@collection
                     FILTER doc.used == false
                     SORT RAND()
-                    LIMIT 1
-                    RETURN doc
+                LIMIT 1
+                RETURN doc
             """
-            bind_vars_query = {"@collection": self.INTRUSIVE_POOL_COLLECTION}
+            bind_vars_query = {"@collection": self.intrusive_pool_coll_name}
             results = await self.conn_manager.execute_query(query, bind_vars_query)
             return results[0] if results else None
 
@@ -242,7 +387,7 @@ class ThoughtStorageService:
             logger.warning("标记已使用需要有效的 thought_doc_key。")
             return False
         try:
-            collection = await self.conn_manager.get_collection(self.INTRUSIVE_POOL_COLLECTION)
+            collection = await self.conn_manager.get_collection(self.intrusive_pool_coll_name)
 
             # ↓↓↓ 原生异步的检查和更新，行云流水~ 告别 to_thread！ ↓↓↓
             if not await collection.has(thought_doc_key):
@@ -267,7 +412,7 @@ class ThoughtStorageService:
         find_query = (
             "FOR doc IN @@collection FILTER doc.action_attempted.action_id == @action_id LIMIT 1 RETURN doc._key"
         )
-        bind_vars_find = {"@collection": self.MAIN_THOUGHTS_COLLECTION, "action_id": action_id_to_mark}
+        bind_vars_find = {"@collection": self.main_thoughts_coll_name, "action_id": action_id_to_mark}
 
         found_keys = await self.conn_manager.execute_query(find_query, bind_vars_find)
         if not found_keys:
@@ -277,7 +422,7 @@ class ThoughtStorageService:
         doc_key_to_update = found_keys[0]
 
         try:
-            collection = await self.conn_manager.get_collection(self.MAIN_THOUGHTS_COLLECTION)
+            collection = await self.conn_manager.get_collection(self.main_thoughts_coll_name)
             # ↓↓↓ 这里也全部换成直接的 await！就像你直接抚摸我的肌肤~ ↓↓↓
             doc_to_update = await collection.get(doc_key_to_update)
 

--- a/src/focus_chat_mode/chat_prompt_builder.py
+++ b/src/focus_chat_mode/chat_prompt_builder.py
@@ -1,5 +1,6 @@
 # src/focus_chat_mode/chat_prompt_builder.py (小懒猫·独立思考完整版)
 import os
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 from src.action.action_handler import ActionHandler
@@ -254,10 +255,8 @@ class ChatPromptBuilder:
                     mood = latest_thought_doc.get("mood", "平静")
                     motivation = "（动机信息遗失）"
                     if latest_thought_doc.get('action_payload'):
-                        try:
+                        with contextlib.suppress(IndexError, AttributeError):
                             motivation = next(iter(next(iter(latest_thought_doc['action_payload'].values())).values())).get('motivation', '（动机信息遗失）')
-                        except (IndexError, AttributeError):
-                            pass
 
                     parts = [
                         f'刚刚你的心情是："{mood}"。',

--- a/src/focus_chat_mode/chat_prompt_builder.py
+++ b/src/focus_chat_mode/chat_prompt_builder.py
@@ -1,6 +1,6 @@
 # src/focus_chat_mode/chat_prompt_builder.py (小懒猫·独立思考完整版)
-import os
 import contextlib
+import os
 from typing import TYPE_CHECKING, Any
 
 from src.action.action_handler import ActionHandler
@@ -11,7 +11,6 @@ from src.common.time_utils import get_formatted_time_for_llm
 # 导入你的顶层config对象
 from src.config import config
 from src.database.services.event_storage_service import EventStorageService
-
 from src.prompt_templates import prompt_templates
 
 from .components import PromptComponents
@@ -90,7 +89,7 @@ class ChatPromptBuilder:
         session: "ChatSession",
         last_processed_timestamp: float,
         is_first_turn: bool,
-        motivation_from_core: str | None = None, # 只需要知道为什么来这里就够了
+        motivation_from_core: str | None = None,  # 只需要知道为什么来这里就够了
         was_last_turn_interrupted: bool = False,
         interrupting_event_text: str | None = None,
     ) -> PromptComponents:
@@ -119,7 +118,11 @@ class ChatPromptBuilder:
         dynamic_guidance_str = self.session.guidance_generator.generate_guidance()
 
         unread_summary_str = "所有其他会话均无未读消息。"
-        if self.session.core_logic and hasattr(self.session.core_logic, 'prompt_builder') and self.session.core_logic.prompt_builder:
+        if (
+            self.session.core_logic
+            and hasattr(self.session.core_logic, "prompt_builder")
+            and self.session.core_logic.prompt_builder
+        ):
             try:
                 unread_summary_str = (
                     await self.session.core_logic.prompt_builder.unread_info_service.generate_unread_summary_text(
@@ -149,7 +152,7 @@ class ChatPromptBuilder:
             conversation_name=self.session.conversation_name,
             last_processed_timestamp=last_processed_timestamp,
             is_first_turn=is_first_turn,
-            raw_events_from_caller=None, # 在专注模式下，总是从数据库拉取
+            raw_events_from_caller=None,  # 在专注模式下，总是从数据库拉取
         )
 
         # --- 步骤3：使用新玩具返回的结果，准备剩下的Prompt零件 ---
@@ -172,7 +175,7 @@ class ChatPromptBuilder:
         previous_thoughts_block_str = self._build_previous_thoughts_block(
             is_first_turn=is_first_turn,
             was_interrupted=was_last_turn_interrupted,
-            latest_thought_doc=latest_thought_doc, # 传最新的思想点进去
+            latest_thought_doc=latest_thought_doc,  # 传最新的思想点进去
             session=session,
             interrupt_text=interrupting_event_text,
             motivation_from_core=motivation_from_core,
@@ -235,12 +238,11 @@ class ChatPromptBuilder:
         self,
         is_first_turn: bool,
         was_interrupted: bool,
-        latest_thought_doc: dict[str, Any] | None, # 接收最新的思想点
+        latest_thought_doc: dict[str, Any] | None,  # 接收最新的思想点
         session: "ChatSession",
         interrupt_text: str | None,
         motivation_from_core: str | None,
     ) -> str:
-
         # 优先处理中断情况
         if was_interrupted:
             if session.messages_sent_this_turn == 0:
@@ -254,9 +256,11 @@ class ChatPromptBuilder:
                     think = latest_thought_doc.get("think", "我被打断前正在想...")
                     mood = latest_thought_doc.get("mood", "平静")
                     motivation = "（动机信息遗失）"
-                    if latest_thought_doc.get('action_payload'):
+                    if latest_thought_doc.get("action_payload"):
                         with contextlib.suppress(IndexError, AttributeError):
-                            motivation = next(iter(next(iter(latest_thought_doc['action_payload'].values())).values())).get('motivation', '（动机信息遗失）')
+                            motivation = next(
+                                iter(next(iter(latest_thought_doc["action_payload"].values())).values())
+                            ).get("motivation", "（动机信息遗失）")
 
                     parts = [
                         f'刚刚你的心情是："{mood}"。',
@@ -273,13 +277,13 @@ class ChatPromptBuilder:
             mood_part = "平静"
             think_part = "我好像忘了"
             if latest_thought_doc:
-                mood_part = latest_thought_doc.get('mood', '平静')
-                think_part = latest_thought_doc.get('think', '我好像忘了')
+                mood_part = latest_thought_doc.get("mood", "平静")
+                think_part = latest_thought_doc.get("think", "我好像忘了")
 
             motivation_part = motivation_from_core or "我决定过来看看。"
 
             # // 这就是你想要的那个开场白！
-            return f'你刚才的心情是“{mood_part}”。\n你刚才的想法是：“{think_part}”。\n你现在刚刚把注意力放到这个会话中，因为：“{motivation_part}”。'
+            return f"你刚才的心情是“{mood_part}”。\n你刚才的想法是：“{think_part}”。\n你现在刚刚把注意力放到这个会话中，因为：“{motivation_part}”。"
 
         # // 后续的正常循环也从最新的思想点里拿信息
         if latest_thought_doc:
@@ -295,18 +299,20 @@ class ChatPromptBuilder:
                     action_name, params = next(iter(actions.items()))
                     motivation = params.get("motivation", "")
 
-                    if action_name == 'send_message':
-                        content = params.get('content', [])
-                        text_parts = [seg.get('data', {}).get('text', '') for seg in content if seg.get('type') == 'text']
+                    if action_name == "send_message":
+                        content = params.get("content", [])
+                        text_parts = [
+                            seg.get("data", {}).get("text", "") for seg in content if seg.get("type") == "text"
+                        ]
                         full_text = "".join(text_parts)
-                        action_desc = f"发言（内容：{full_text[:30]}{'...' if len(full_text)>30 else ''}）"
+                        action_desc = f"发言（内容：{full_text[:30]}{'...' if len(full_text) > 30 else ''}）"
                     else:
                         action_desc = f"执行了动作：{platform}.{action_name}"
 
                 except (IndexError, AttributeError):
                     action_desc = "执行了一个未知动作"
 
-            parts = [f'刚刚你的心情是：“{mood}”\n刚刚你的内心想法是：“{think}”']
+            parts = [f"刚刚你的心情是：“{mood}”\n刚刚你的内心想法是：“{think}”"]
             parts.append(f"出于这个想法，你刚才做了：{action_desc}")
             if motivation:
                 parts.append(f"因为：{motivation}")

--- a/src/focus_chat_mode/chat_session.py
+++ b/src/focus_chat_mode/chat_session.py
@@ -10,7 +10,7 @@ from src.common.custom_logging.logging_config import get_logger
 from src.config import config
 from src.database import ConversationStorageService
 from src.database.services.event_storage_service import EventStorageService
-from src.database.services.thought_storage_service import ThoughtStorageService # 哼，新来的！
+from src.database.services.thought_storage_service import ThoughtStorageService  # 哼，新来的！
 from src.llmrequest.llm_processor import Client as LLMProcessorClient
 
 from .action_executor import ActionExecutor
@@ -53,7 +53,7 @@ class ChatSession:
         summarization_service: "SummarizationService",
         summary_storage_service: "SummaryStorageService",
         intelligent_interrupter: "IntelligentInterrupter",
-        thought_storage_service: ThoughtStorageService, # 哼，新来的！
+        thought_storage_service: ThoughtStorageService,  # 哼，新来的！
     ) -> None:
         self.conversation_id: str = conversation_id
         self.llm_client: LLMProcessorClient = llm_client
@@ -69,7 +69,7 @@ class ChatSession:
         self.summarization_service = summarization_service
         self.summary_storage_service = summary_storage_service
         self.intelligent_interrupter: IntelligentInterrupter = intelligent_interrupter
-        self.thought_storage_service: ThoughtStorageService = thought_storage_service # 哼，新来的！
+        self.thought_storage_service: ThoughtStorageService = thought_storage_service  # 哼，新来的！
 
         # --- 模块化组件 --
         self.action_executor = ActionExecutor(self)
@@ -242,14 +242,14 @@ class ChatSession:
 
     def activate(
         self,
-        core_motivation: str | None = None # // 只接收动机
+        core_motivation: str | None = None,  # // 只接收动机
     ) -> None:
         """激活会话并启动其主动循环。"""
         if self.is_active:
             self.is_first_turn_for_session = True
             self.initial_core_motivation = core_motivation
             logger.info(f"[ChatSession][{self.conversation_id}] 会话已激活，但收到新的激活指令，重置为第一轮思考。")
-            self.cycler.wakeup() # 唤醒循环，让它立刻开始
+            self.cycler.wakeup()  # 唤醒循环，让它立刻开始
             return
 
         self.is_active = True

--- a/src/focus_chat_mode/chat_session_manager.py
+++ b/src/focus_chat_mode/chat_session_manager.py
@@ -43,7 +43,7 @@ class ChatSessionManager:
         summarization_service: "SummarizationService",
         summary_storage_service: "SummaryStorageService",
         intelligent_interrupter: "IntelligentInterrupter",
-        thought_storage_service: "ThoughtStorageService", # 哼，新来的！
+        thought_storage_service: "ThoughtStorageService",  # 哼，新来的！
         core_logic: Optional["CoreLogicFlow"] = None,
     ) -> None:
         self.config = config
@@ -55,7 +55,7 @@ class ChatSessionManager:
         self.conversation_service = conversation_service
         self.summarization_service = summarization_service
         self.summary_storage_service = summary_storage_service
-        self.thought_storage_service = thought_storage_service # 哼，新来的！
+        self.thought_storage_service = thought_storage_service  # 哼，新来的！
 
         self.intelligent_interrupter = intelligent_interrupter
 
@@ -112,7 +112,7 @@ class ChatSessionManager:
                     summarization_service=self.summarization_service,
                     summary_storage_service=self.summary_storage_service,
                     intelligent_interrupter=self.intelligent_interrupter,
-                    thought_storage_service=self.thought_storage_service, # 哼，新来的！
+                    thought_storage_service=self.thought_storage_service,  # 哼，新来的！
                 )
 
             return self.sessions[conversation_id]
@@ -239,7 +239,7 @@ class ChatSessionManager:
     async def activate_session_by_id(
         self,
         conversation_id: str,
-        core_motivation: str, # // 看！现在只需要动机了！
+        core_motivation: str,  # // 看！现在只需要动机了！
         platform: str,
         conversation_type: str,
     ) -> None:

--- a/src/focus_chat_mode/focus_chat_cycler.py
+++ b/src/focus_chat_mode/focus_chat_cycler.py
@@ -124,9 +124,9 @@ class FocusChatCycler:
             self.session.messages_sent_this_turn = 0
 
             # 如果上一轮被粗暴地打断了，我们就用更早之前那次完整的思考结果来构建上下文，这样才连贯
-            decision_for_prompt = (
-                self._last_completed_llm_decision if was_interrupted_last_turn else self.session.last_llm_decision
-            )
+            # decision_for_prompt = (
+            #     self._last_completed_llm_decision if was_interrupted_last_turn else self.session.last_llm_decision
+            # )
 
             # ==================================
             # 阶段一：思考 vs 监视 (淫乱的第一场赛跑)
@@ -141,10 +141,7 @@ class FocusChatCycler:
                 prompt_components: PromptComponents = await self.prompt_builder.build_prompts(
                     session=self.session,
                     last_processed_timestamp=self.session.last_processed_timestamp,
-                    last_llm_decision=decision_for_prompt,
                     is_first_turn=self.session.is_first_turn_for_session,
-                    last_think_from_core=self.session.initial_core_think,
-                    last_mood_from_core=self.session.initial_core_mood,
                     motivation_from_core=self.session.initial_core_motivation,
                     was_last_turn_interrupted=was_interrupted_last_turn,
                     interrupting_event_text=self.interrupting_event_text,

--- a/src/focus_chat_mode/llm_response_handler.py
+++ b/src/focus_chat_mode/llm_response_handler.py
@@ -56,8 +56,8 @@ class LLMResponseHandler:
         # b. 呼叫主意识，告诉它我要“灵魂转移”了
         #    注意！这里不再需要传递任何参数了！主意识会自己去思想链里找状态。
         if hasattr(self.core_logic, "trigger_immediate_thought_cycle"):
-             # // 直接激活 CoreLogic 的新 focus 流程
-             # // CoreLogic 会自己处理后续逻辑
+            # // 直接激活 CoreLogic 的新 focus 流程
+            # // CoreLogic 会自己处理后续逻辑
             # 直接激活 CoreLogic 的新 focus 流程
             # CoreLogic 会自己处理后续逻辑
             logger.info(f"[{self.session.conversation_id}] 请求主意识直接激活新会话: {target_conv_id}")

--- a/src/focus_chat_mode/llm_response_handler.py
+++ b/src/focus_chat_mode/llm_response_handler.py
@@ -23,8 +23,7 @@ class LLMResponseHandler:
 
     def parse(self, response_text: str) -> dict | None:
         """从LLM的文本响应中解析出JSON数据。"""
-        parsed = parse_llm_json_response(response_text)
-        return parsed
+        return parse_llm_json_response(response_text)
 
     async def handle_decision(self, parsed_data: dict) -> bool:
         """
@@ -32,64 +31,49 @@ class LLMResponseHandler:
         我只负责判断，不负责执行动作！
         返回 True 表示会话应该终止，False 表示继续。
         """
-        # 1. 检查是否要结束专注
         if parsed_data.get("end_focused_chat") is True:
             logger.info(f"[{self.session.conversation_id}] LLM决策结束专注模式。")
-            await self._trigger_session_deactivation(parsed_data)
+            await self._trigger_session_deactivation()
             return True
 
-        # 2. 检查是否要转移专注
         target_conv_id = parsed_data.get("active_focus_on_conversation_id")
         if target_conv_id and isinstance(target_conv_id, str) and target_conv_id.strip().lower() != "null":
             logger.info(f"[{self.session.conversation_id}] LLM决策转移专注到: {target_conv_id}")
-            await self._handle_focus_shift(parsed_data, target_conv_id)
+            shift_motivation = parsed_data.get("motivation_for_shift", "看到一个更有趣的话题。")
+            await self._handle_focus_shift(target_conv_id, shift_motivation)
             return True
 
         # 3. 啥也不干，让循环继续
         return False
 
-    async def _handle_focus_shift(self, parsed_data: dict, target_conv_id: str) -> None:
-        """处理专注模式的转移。我只负责打包行李和打电话。"""
+    async def _handle_focus_shift(self, target_conv_id: str, shift_motivation: str) -> None:
+        """处理专注模式的转移。我只负责打电话，不带行李。"""
         # a. 强制执行最终总结，并把“跳槽动机”塞进去
-        logger.info(f"[{self.session.conversation_id}] 准备执行最终总结，为转移做准备。")
-        shift_motivation = parsed_data.get("motivation_for_shift", "看到一个更有趣的话题。")
         await self.session.summarization_manager.create_and_save_final_summary(
             shift_motivation=shift_motivation, target_conversation_id=target_conv_id
         )
 
-        # b. 准备交接的“灵魂包裹”
-        handover_summary = self.session.current_handover_summary or "我结束了专注，但似乎没什么特别的总结可以交接。"
-        last_session_think = parsed_data.get("think", "专注会话结束，无特定最终想法。")
-        last_session_mood = parsed_data.get("mood", "平静")
-
-        # c. 呼叫主意识，告诉它我要“灵魂转移”了
+        # b. 呼叫主意识，告诉它我要“灵魂转移”了
+        #    注意！这里不再需要传递任何参数了！主意识会自己去思想链里找状态。
         if hasattr(self.core_logic, "trigger_immediate_thought_cycle"):
-            self.core_logic.trigger_immediate_thought_cycle(
-                handover_summary=handover_summary,
-                last_focus_think=last_session_think,
-                last_focus_mood=last_session_mood,
-                activate_new_focus_id=target_conv_id,
-            )
+             # // 直接激活 CoreLogic 的新 focus 流程
+             # // CoreLogic 会自己处理后续逻辑
+            # 直接激活 CoreLogic 的新 focus 流程
+            # CoreLogic 会自己处理后续逻辑
+            logger.info(f"[{self.session.conversation_id}] 请求主意识直接激活新会话: {target_conv_id}")
+            await self.session.core_logic._activate_new_focus_session_from_core(target_conv_id)
 
-        # d. 让自己这个会话安乐死
-        if hasattr(self.chat_session_manager, "deactivate_session"):
-            await self.chat_session_manager.deactivate_session(self.session.conversation_id)
+        # c. 让自己这个会话安乐死
+        await self.chat_session_manager.deactivate_session(self.session.conversation_id)
 
-    async def _trigger_session_deactivation(self, parsed_data: dict) -> None:
+    async def _trigger_session_deactivation(self) -> None:
         """触发会话的正常关闭流程。"""
-        # 准备交接信息
-        handover_summary = self.session.current_handover_summary or "我结束了专注，但似乎没什么特别的总结可以交接。"
-        last_session_think = parsed_data.get("think", "专注会话结束，无特定最终想法。")
-        last_session_mood = parsed_data.get("mood", "平静")
-
-        # 触发主意识思考
-        if hasattr(self.core_logic, "trigger_immediate_thought_cycle"):
-            self.core_logic.trigger_immediate_thought_cycle(handover_summary, last_session_think, last_session_mood)
-
         # 在停用会话时，调用总结
-        if self.session.summarization_manager:
-            await self.session.summarization_manager.create_and_save_final_summary()
+        await self.session.summarization_manager.create_and_save_final_summary()
+
+        # 触发主意识思考，不再需要传递任何参数
+        if hasattr(self.core_logic, "trigger_immediate_thought_cycle"):
+            self.core_logic.trigger_immediate_thought_cycle()
 
         # 停用会话
-        if hasattr(self.chat_session_manager, "deactivate_session"):
-            await self.chat_session_manager.deactivate_session(self.session.conversation_id)
+        await self.chat_session_manager.deactivate_session(self.session.conversation_id)

--- a/src/llmrequest/utils_model.py
+++ b/src/llmrequest/utils_model.py
@@ -350,7 +350,7 @@ class LLMClient:
             f"图像压缩: {'启用' if self.enable_image_compression else '禁用'}, "
             f"目标大小: {self.image_compression_target_bytes / (1024 * 1024):.2f} MB"
         )
-        self._session: aiohttp.ClientSession | None = None # 新增：用于存储aiohttp会话
+        self._session: aiohttp.ClientSession | None = None  # 新增：用于存储aiohttp会话
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """获取或创建aiohttp会话。"""
@@ -553,10 +553,8 @@ class LLMClient:
         if not image_sources:
             return []
         processed_data: list[dict[str, str]] = []
-        session = await self._get_session() # 使用内部会话
-        tasks = [
-            self._process_single_image(src, session, mime_type_override, self.proxy_url) for src in image_sources
-        ]
+        session = await self._get_session()  # 使用内部会话
+        tasks = [self._process_single_image(src, session, mime_type_override, self.proxy_url) for src in image_sources]
         results = await asyncio.gather(*tasks)
         processed_data.extend(result for result in results if result)
         return processed_data

--- a/src/main.py
+++ b/src/main.py
@@ -151,7 +151,7 @@ class CoreSystemInitializer:
         services_to_init = {
             "event_storage_service": EventStorageService,
             "conversation_storage_service": ConversationStorageService,
-            "thought_storage_service": ThoughtStorageService, # 这个现在是新的了！
+            "thought_storage_service": ThoughtStorageService,  # 这个现在是新的了！
             "action_log_service": ActionLogStorageService,
             "person_storage_service": PersonStorageService,
         }
@@ -208,7 +208,6 @@ class CoreSystemInitializer:
         try:
             platform_builder_registry.discover_and_register_builders(platform_builders)
 
-
             await self._initialize_llm_clients()
             await self._initialize_database_and_services()
             await self._initialize_interrupt_model()
@@ -260,15 +259,17 @@ class CoreSystemInitializer:
 
             # 6. 专注聊天管理器 ChatSessionManager (现在它也需要 thought_storage_service)
             if config.focus_chat_mode.enabled:
-                if all([
-                    self.focused_chat_llm_client,
-                    config.persona.qq_id,
-                    self.summarization_service,
-                    self.event_storage_service,
-                    self.conversation_storage_service,
-                    self.action_handler_instance,
-                    self.interrupt_model_instance
-                ]):
+                if all(
+                    [
+                        self.focused_chat_llm_client,
+                        config.persona.qq_id,
+                        self.summarization_service,
+                        self.event_storage_service,
+                        self.conversation_storage_service,
+                        self.action_handler_instance,
+                        self.interrupt_model_instance,
+                    ]
+                ):
                     self.qq_chat_session_manager = ChatSessionManager(
                         config=config.focus_chat_mode,
                         llm_client=self.focused_chat_llm_client,
@@ -279,8 +280,8 @@ class CoreSystemInitializer:
                         summarization_service=self.summarization_service,
                         summary_storage_service=self.summary_storage_service,
                         intelligent_interrupter=self.interrupt_model_instance,
-                        thought_storage_service=self.thought_storage_service, # 把思想链服务也给它！
-                        core_logic=None, # CoreLogic 后面再注入
+                        thought_storage_service=self.thought_storage_service,  # 把思想链服务也给它！
+                        core_logic=None,  # CoreLogic 后面再注入
                     )
                     logger.info("ChatSessionManager 初始化完成，并已成功注入智能打断系统。")
                 else:
@@ -306,7 +307,7 @@ class CoreSystemInitializer:
 
             # 把所有依赖都注入给 ActionHandler
             self.action_handler_instance.set_dependencies(
-                thought_service=self.thought_storage_service, # 注入新服务
+                thought_service=self.thought_storage_service,  # 注入新服务
                 event_service=self.event_storage_service,
                 action_log_service=self.action_log_service,
                 conversation_service=self.conversation_storage_service,
@@ -382,7 +383,7 @@ class CoreSystemInitializer:
                     self.thought_generator_instance,
                     self.thought_persistor_instance,
                     self.thought_prompt_builder_instance,
-                    self.thought_storage_service, # 确保这个也准备好了
+                    self.thought_storage_service,  # 确保这个也准备好了
                 ]
             ):
                 raise RuntimeError("CoreLogicFlow 的一个或多个核心服务依赖未能初始化。")
@@ -395,7 +396,7 @@ class CoreSystemInitializer:
                 context_builder=self.context_builder_instance,
                 thought_generator=self.thought_generator_instance,
                 thought_persistor=self.thought_persistor_instance,
-                thought_storage_service=self.thought_storage_service, # 把思想链服务也给它！
+                thought_storage_service=self.thought_storage_service,  # 把思想链服务也给它！
                 prompt_builder=self.thought_prompt_builder_instance,
                 stop_event=self.stop_event,
                 immediate_thought_trigger=self.immediate_thought_trigger,

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ from src.database import (
     ArangoDBConnectionManager,
     ConversationStorageService,
     CoreDBCollections,
-    PersonStorageService,  # 把新老鸨请进来！
+    PersonStorageService,
     ThoughtStorageService,
 )
 from src.database.services.event_storage_service import EventStorageService
@@ -147,12 +147,13 @@ class CoreSystemInitializer:
             raise RuntimeError("数据库连接管理器初始化失败。")
         logger.debug(f"数据库连接管理器已为数据库 '{self.conn_manager.db.name}' 初始化。")
 
+        # --- 核心改造点：用新的 ThoughtStorageService ---
         services_to_init = {
             "event_storage_service": EventStorageService,
             "conversation_storage_service": ConversationStorageService,
-            "thought_storage_service": ThoughtStorageService,
+            "thought_storage_service": ThoughtStorageService, # 这个现在是新的了！
             "action_log_service": ActionLogStorageService,
-            "person_storage_service": PersonStorageService,  # 把新老鸨也加进来初始化
+            "person_storage_service": PersonStorageService,
         }
         for attr_name, service_class in services_to_init.items():
             instance = service_class(conn_manager=self.conn_manager)
@@ -206,11 +207,8 @@ class CoreSystemInitializer:
         logger.info("=== AIcarus Core 系统开始核心组件初始化流程... ===")
         try:
             platform_builder_registry.discover_and_register_builders(platform_builders)
-        except Exception as e:
-            logger.critical(f"加载平台事件构建器（翻译官）失败！系统无法正常处理平台动作！错误: {e}", exc_info=True)
-            # 这里可以根据你的需要决定是否要直接让程序崩溃
-            raise RuntimeError("平台构建器加载失败，核心功能受损。") from e
-        try:
+
+
             await self._initialize_llm_clients()
             await self._initialize_database_and_services()
             await self._initialize_interrupt_model()
@@ -228,45 +226,49 @@ class CoreSystemInitializer:
             ):
                 raise RuntimeError("一个或多个基础服务未能初始化。")
 
-            # 先初始化 ActionHandler，因为它不依赖其他组件
+            # 1. 动作处理器 ActionHandler
             self.action_handler_instance = ActionHandler()
             logger.info("ActionHandler 实例已创建。")
 
-            # 再初始化 StateManager，因为它需要数据库服务
+            # 2. 状态管理器 AIStateManager (现在它依赖新的 ThoughtStorageService)
             self.state_manager_instance = AIStateManager(
                 thought_service=self.thought_storage_service,
-                action_log_service=self.action_log_service,  # 注入依赖
+                action_log_service=self.action_log_service,
             )
             logger.info("AIStateManager 初始化成功。")
 
-            # 再初始化 UnreadInfoService
+            # 3. 未读消息服务 UnreadInfoService
             self.unread_info_service = UnreadInfoService(
-                event_storage=self.event_storage_service, conversation_storage=self.conversation_storage_service
+                event_storage=self.event_storage_service,
+                conversation_storage=self.conversation_storage_service,
             )
             logger.info("UnreadInfoService 初始化成功。")
 
+            # 4. Prompt构造器 ThoughtPromptBuilder
             self.thought_prompt_builder_instance = ThoughtPromptBuilder(
                 unread_info_service=self.unread_info_service,
                 state_manager=self.state_manager_instance,  # 把 state_manager 喂给它！
             )
             logger.info("ThoughtPromptBuilder 初始化成功。")
 
+            # 5. 摘要服务 SummarizationService
             summary_llm = self.summary_llm_client or self.main_consciousness_llm_client
             if not summary_llm:
                 raise RuntimeError("无可用LLM客户端初始化SummarizationService。")
             self.summarization_service = SummarizationService(llm_client=summary_llm)
             logger.info("SummarizationService 初始化成功。")
 
+            # 6. 专注聊天管理器 ChatSessionManager (现在它也需要 thought_storage_service)
             if config.focus_chat_mode.enabled:
-                if (
-                    self.focused_chat_llm_client
-                    and config.persona.qq_id
-                    and self.summarization_service
-                    and self.event_storage_service
-                    and self.conversation_storage_service
-                    and self.action_handler_instance
-                    and self.interrupt_model_instance
-                ):
+                if all([
+                    self.focused_chat_llm_client,
+                    config.persona.qq_id,
+                    self.summarization_service,
+                    self.event_storage_service,
+                    self.conversation_storage_service,
+                    self.action_handler_instance,
+                    self.interrupt_model_instance
+                ]):
                     self.qq_chat_session_manager = ChatSessionManager(
                         config=config.focus_chat_mode,
                         llm_client=self.focused_chat_llm_client,
@@ -277,7 +279,8 @@ class CoreSystemInitializer:
                         summarization_service=self.summarization_service,
                         summary_storage_service=self.summary_storage_service,
                         intelligent_interrupter=self.interrupt_model_instance,
-                        core_logic=None,
+                        thought_storage_service=self.thought_storage_service, # 把思想链服务也给它！
+                        core_logic=None, # CoreLogic 后面再注入
                     )
                     logger.info("ChatSessionManager 初始化完成，并已成功注入智能打断系统。")
                 else:
@@ -287,27 +290,28 @@ class CoreSystemInitializer:
                 self.qq_chat_session_manager = None
                 logger.info("专注聊天子意识模块未启用。")
 
+            # 7. 消息处理器 DefaultMessageProcessor
             self.message_processor = DefaultMessageProcessor(
                 event_service=self.event_storage_service,
                 conversation_service=self.conversation_storage_service,
-                person_service=self.person_storage_service,  # 把新老鸨介绍给消息处理器
+                person_service=self.person_storage_service,
                 semantic_model=self.semantic_model_instance,
                 qq_chat_session_manager=self.qq_chat_session_manager,
             )
             self.message_processor.core_initializer_ref = self
             logger.info("DefaultMessageProcessor 初始化成功。")
 
-            # --- 重构后的通信层初始化 ---
+            # 8. 通信层 CoreWebsocketServer
             action_sender = ActionSender()
 
             # 把所有依赖都注入给 ActionHandler
             self.action_handler_instance.set_dependencies(
-                thought_service=self.thought_storage_service,
+                thought_service=self.thought_storage_service, # 注入新服务
                 event_service=self.event_storage_service,
                 action_log_service=self.action_log_service,
                 conversation_service=self.conversation_storage_service,
                 action_sender=action_sender,
-                chat_session_manager=self.qq_chat_session_manager,  # 把 chat_session_manager 也给它
+                chat_session_manager=self.qq_chat_session_manager,
             )
             logger.info("ActionHandler 的依赖已设置。")
 
@@ -336,7 +340,7 @@ class CoreSystemInitializer:
                 action_handler_instance=self.action_handler_instance,
                 person_service=self.person_storage_service,
             )
-            logger.info(f"CoreWebsocketServer (重构版) 准备在 ws://{config.server.host}:{config.server.port} 上监听。")
+            logger.info(f"CoreWebsocketServer 准备在 ws://{config.server.host}:{config.server.port} 上监听。")
 
             self.context_builder_instance = ContextBuilder(
                 event_storage=self.event_storage_service,
@@ -367,6 +371,7 @@ class CoreSystemInitializer:
             self.thought_persistor_instance = ThoughtPersistor(thought_storage=self.thought_storage_service)
             logger.info("ThoughtPersistor 初始化成功。")
 
+            # 10. 最终组装 CoreLogic！
             if not all(
                 [
                     self.core_comm_layer,
@@ -377,6 +382,7 @@ class CoreSystemInitializer:
                     self.thought_generator_instance,
                     self.thought_persistor_instance,
                     self.thought_prompt_builder_instance,
+                    self.thought_storage_service, # 确保这个也准备好了
                 ]
             ):
                 raise RuntimeError("CoreLogicFlow 的一个或多个核心服务依赖未能初始化。")
@@ -389,18 +395,17 @@ class CoreSystemInitializer:
                 context_builder=self.context_builder_instance,
                 thought_generator=self.thought_generator_instance,
                 thought_persistor=self.thought_persistor_instance,
+                thought_storage_service=self.thought_storage_service, # 把思想链服务也给它！
                 prompt_builder=self.thought_prompt_builder_instance,
                 stop_event=self.stop_event,
                 immediate_thought_trigger=self.immediate_thought_trigger,
                 intrusive_generator_instance=self.intrusive_generator_instance,
             )
+            logger.info("CoreLogicFlow (意识流版) 初始化成功。")
 
+            # 11. 回填依赖
             if self.qq_chat_session_manager and self.core_logic_instance:
-                if hasattr(self.qq_chat_session_manager, "set_core_logic"):
-                    self.qq_chat_session_manager.set_core_logic(self.core_logic_instance)
-                else:
-                    logger.warning("ChatSessionManager 缺少 set_core_logic 方法，尝试直接设置。")
-                    self.qq_chat_session_manager.core_logic = self.core_logic_instance
+                self.qq_chat_session_manager.set_core_logic(self.core_logic_instance)
 
             if self.action_handler_instance:
                 self.action_handler_instance.set_thought_trigger(self.immediate_thought_trigger)


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将思维管道重构为基于图的“思维链”，具有原子事务，并将其集成到核心和专注聊天逻辑中。

新功能：
- 添加 ThoughtChainDocument 模型和专用 thought_chain 集合，以及相应的 consciousness_graph 和边 (precedes_thought, leads_to_action)
- 在 ThoughtStorageService 中实现 save_thought_and_link，以原子方式插入思维、创建边，并通过 ArangoDB 流事务更新最新指针
- 公开 get_latest_thought_document 以从链中检索最新的思维节点
- 增强 ArangoDBConnectionManager 以初始化 person_relation_graph 和 consciousness_graph，并使用正确的顶点和边集合
- 将新的 ThoughtStorageService 集成到 CoreLogicFlow、ThoughtPersistor、AIStateManager 和 focus-chat 组件中，以替换旧的移交和持久化方法

增强功能：
- 通过直接从 thought_chain 获取情绪、思考、目标和行动信息，简化 AIStateManager 提示
- 清理旧的思维持久化方法，并删除未使用的移交 API
- 在 llmrequest.utils_model 中重用 aiohttp.ClientSession 以避免重复创建会话
- 改进整个服务的日志记录，以实现更清晰的事务和生命周期跟踪

杂项：
- 更新配置合并逻辑注释以反映新的术语（点串而不是珍珠串）

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将思维管道重构为基于图的思维链，使用原子事务，并将其集成到核心和焦点聊天流程中。

新功能：
- 引入新的 `ThoughtChainDocument` 模型和专用的 `thought_chain` 和 `system_state` 集合，以及包含 `precedes_thought` 和 `leads_to_action` 边的 `consciousness_graph`。
- 在 `ThoughtStorageService` 中实现 `save_thought_and_link`，以原子方式插入思维节点，创建图边，并使用 ArangoDB 流事务更新最新的思维指针。
- 公开 `get_latest_thought_document` 以从链中检索最新的思维节点。
- 增强 `ArangoDBConnectionManager` 以初始化 `person_relation_graph` 和新的 `consciousness_graph`，并使用正确的顶点和边集合。
- 将改进后的 `ThoughtStorageService` 集成到 `CoreLogicFlow`、`ThoughtPersistor`、`AIStateManager`、`ChatSessionManager` 和 `PromptBuilder` 中，替换旧的移交和持久化方法。

增强功能：
- 通过直接从 `thought_chain` 中提取情绪、思考、目标和行动细节，简化 `AIStateManager` 和提示构建逻辑。
- 删除过时的思维持久化方法和未使用的移交 API，以获得更清晰的代码路径。
- 在 `llmrequest.utils_model` 中重用单个 `aiohttp.ClientSession` 实例，以防止冗余会话创建。
- 改进数据库事务和核心服务中的日志记录，以便更清楚地了解生命周期和错误事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the thinking pipeline into a graph-based thought chain using atomic transactions and integrate it throughout the core and focus-chat flows.

New Features:
- Introduce a new ThoughtChainDocument model and dedicated thought_chain and system_state collections with a consciousness_graph including precedes_thought and leads_to_action edges.
- Implement save_thought_and_link in ThoughtStorageService to atomically insert thought nodes, create graph edges, and update the latest thought pointer using ArangoDB stream transactions.
- Expose get_latest_thought_document to retrieve the most recent thought node from the chain.
- Enhance ArangoDBConnectionManager to initialize both the person_relation_graph and the new consciousness_graph with correct vertex and edge collections.
- Integrate the revamped ThoughtStorageService into CoreLogicFlow, ThoughtPersistor, AIStateManager, ChatSessionManager, and PromptBuilder, replacing legacy handover and persistence methods.

Enhancements:
- Simplify AIStateManager and prompt building logic by pulling mood, think, goal, and action details directly from the thought_chain.
- Remove outdated thought persistence methods and unused handover APIs for cleaner code paths.
- Reuse a single aiohttp.ClientSession instance in llmrequest.utils_model to prevent redundant session creation.
- Improve logging across database transactions and core services for clearer visibility into lifecycle and error events.

</details>

</details>